### PR TITLE
Use 'python2.7' in shebang; make script executable

### DIFF
--- a/scripts/google-java-format-diff.py
+++ b/scripts/google-java-format-diff.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 #
 #===- google-java-format-diff.py - google-java-format Diff Reformatter -----===#
 #


### PR DESCRIPTION
On modern systems 'python' is most likely symlinked to python3, but
'google-java-format-diff.py' uses python2 syntax. Therefore it is better
to explicitly use 'python2'. Also changed file mode of the script (chmod
a+x) to make it executable.