### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/core/src/main/scripts/google-java-format.el
+++ b/core/src/main/scripts/google-java-format.el
@@ -2,6 +2,8 @@
 ;;
 ;; Copyright 2015 Google, Inc. All Rights Reserved.
 ;;
+;; Package-Requires: ((emacs "24"))
+;;
 ;; Licensed under the Apache License, Version 2.0 (the "License");
 ;; you may not use this file except in compliance with the License.
 ;; You may obtain a copy of the License at


### PR DESCRIPTION
lexical-binding was introduced since Emacs 24.