### PR TITLE
Add 'Building' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@
 [Google Java Style][].
 
 [Google Java Style]: http://google-styleguide.googlecode.com/svn/trunk/javaguide.html
+
+Building
+--------
+
+To build google-java-format from source, you will need copy IntelliJ's
+platform JARs from a local IntelliJ install; see
+[`install-idea-jars.sh`](idea_plugin/src/main/scripts/install-idea-jars.sh).
+Alternatively, you can skip building the IntelliJ plugin:
+
+    mvn -pl '!idea_plugin' install


### PR DESCRIPTION
Links to install-idea-jars.sh and documents how to skip building the IntelliJ plugin