### PR TITLE
google-java-format-diff.py: improve finding of executable

### DIFF
--- a/scripts/google-java-format-diff.py
+++ b/scripts/google-java-format-diff.py
@@ -29,8 +29,9 @@ import string
 import subprocess
 import StringIO
 import sys
+from distutils.spawn import find_executable
 
-binary = '/usr/bin/google-java-format'
+binary = find_executable('google-java-format') or '/usr/bin/google-java-format'
 
 def main():
   parser = argparse.ArgumentParser(description=


### PR DESCRIPTION
use python's ability to find an executable rather than assuming the executable is in /usr/bin