### PR TITLE
Preserve file attributes during in place format

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
@@ -217,6 +217,22 @@ class FormatFileCallable implements Callable<Boolean> {
       }
     } else {
       String tempFileName = fileToFormat.fileName() + '#';
+      try {
+        Files.copy(
+              Paths.get(fileToFormat.fileName()),
+              Paths.get(tempFileName),
+              StandardCopyOption.COPY_ATTRIBUTES);
+      } catch (IOException e) {
+        synchronized (outputLock) {
+          errWriter
+              .append(tempFileName)
+              .append(": cannot create temp file: ")
+              .append(e.getMessage())
+              .append('\n')
+              .flush();
+        }
+        return false;
+      }
       try (Writer writer =
           new OutputStreamWriter(
               new BufferedOutputStream(new FileOutputStream(tempFileName)),


### PR DESCRIPTION
Fixes issue #38. See the issue for a description of the problem and steps to reproduce.

## Problem

If a file has non-default permissions, those permissions are lost when doing an in place format.

## Solution

Preserve existing file attributes while doing an in place format.

## Implementation

We copy the original file to a temporary file rather than creating a new temporary file from scratch. The copy is done with `StandardCopyOption.COPY_ATTRIBUTES` so that the original attributes are preserved. The existing code already truncates the temporary file if it exists, so the copy will be truncated when we write the formatted content to it.

## Testing done

**Automated testing:** Added a new unit test that exercise in place formatting against a file by setting the executable bit on it and then running in place formatting. This test fails on trunk prior to this fix on my Mac OS X system, where new files don't have the execute bit by default. It passes by accident prior to this fix on my Windows system, but only because new files have the execute bit set by default on my Windows system. My new test passes on all systems I could test with my fix. I thought about writing a test that tests the opposite behavior (i.e., that a file with the execute bit unset retains the unset bit), but I was unable to write such a test because I couldn't find a way to reliably unset execute permissions across platforms (e.g., `File.setExecutable` always returned `false` on Windows). I had similar problems trying to use other attributes in the test (e.g., setting the file creation time always failed on Mac OS X). I settled on the current test as a way to get some coverage on some platforms, which is better than nothing.

**Manual testing:** Manually tested that on Windows, in place format retained an unset execute bit on files where the execute bit was originally unset, despite the fact that the default behavior for new files is to have the execute bit set.