### PR TITLE
'jfmt' tool for the fast formating

### DIFF
--- a/scripts/jfmt.py
+++ b/scripts/jfmt.py
@@ -2,7 +2,7 @@
 
 from __future__ import print_function
 import sys, os
-
+import argparse
 
 # Purpose:
 # Format all .java files in the directory, including child
@@ -38,10 +38,9 @@ def origin_path():
 GJF = "google-java-format-1.0-all-deps.jar"
 # Command which will be executed by the os.system()
 COMMAND = "java -jar " + origin_path() + "/" + GJF
-# Verbose output.
-DEBUG = False
 
-def format_files(p):
+
+def format_files(p, verbose):
     '''
     Format files in `p` directory.
     '''
@@ -51,34 +50,67 @@ def format_files(p):
                 fpath = dirpath + '/' + fname
                 c = COMMAND + " --replace " + fpath
                 os.system(c)
-                if DEBUG:
+                if verbose:
                     print("Path: ", dirpath)
                     print("Name: ", fname)
 
-def format_file(p):
+
+def format_file(p, verbose):
     '''
     Format the file.
     '''
+    if verbose:
+        print("Format file: ", p)
     c = COMMAND + " --replace " + p
     os.system(c)
 
+
 def parse_argv():
-    if len(sys.argv) == 2:
-        p = os.path.abspath(sys.argv[1])
-        if os.path.isfile(p):
-            format_file(p)
-        if os.path.isdir(p):
-            format_files(p)
-    if len(sys.argv) == 1:
-        p = os.getcwd()
-        format_files(p)
+    parser = argparse.ArgumentParser(
+        description='Format all .java files in the directory,' +
+        ' including child directories and their .java files, ' +
+        'or just a single .java file.')
+    parser.add_argument('--verbose',
+                        '-v',
+                        action='store_true',
+                        help='verbose flag')
+    parser.add_argument('file',
+                        nargs='?',
+                        default='none',
+                        help='path to .java file or folder')
+    p = parser.parse_args()
+
+    # Format .java files in current working directory.
+    if len(sys.argv) == 1 or len(sys.argv) == 2 and p.verbose:
+        path = os.getcwd()
+        if p.verbose:
+            print("Path: ", path)
+            format_files(path, True)
+        else:
+            format_files(path, False)
+
+    # Format .java files in proveded directory, or format .java
+    # if proveded argument is a path to it.
+    if p.file != 'none':
+        if os.path.isfile(p.file):
+            if p.verbose:
+                format_file(p.file, True)
+            else:
+                format_file(p.file, False)
+        if os.path.isdir(p.file):
+            if p.verbose:
+                print("Format dir: ", p.file)
+                format_files(p.file, True)
+            else:
+                format_files(p.file, False)
+
 
 def print_help(reason):
     if reason == "jar":
         print("ERROR: No " + GJF + " found")
-        print("\nIn order to use 'jfmt' you need to put " +
-              "'google-java-format-1.0-all-deps.jar' into the folder " +
-              "with 'jfmt' script.\n")
+        print("\nIn order to use 'jfmt' you need to put " + GJF +
+              " into the folder " + "with 'jfmt' script.\n")
+
 
 def check_source():
     '''
@@ -91,13 +123,14 @@ def check_source():
     else:
         return False
 
+
 def main():
     if check_source():
-        print("Processing...")
         parse_argv()
-        print("Done.")
+        print("Done")
     else:
         print_help("jar")
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/jfmt.py
+++ b/scripts/jfmt.py
@@ -30,8 +30,9 @@ def origin_path():
     return os.path.dirname(os.path.realpath(sys.argv[0]))
 
 # Constants:
-# Command which will be executed by the os.system()
+# Current version name
 GJF = "google-java-format-1.0-all-deps.jar"
+# Command which will be executed by the os.system()
 COMMAND = "java -jar " + origin_path() + "/" + GJF
 # Verbose output.
 DEBUG = False

--- a/scripts/jfmt.py
+++ b/scripts/jfmt.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python2.7
+
+from __future__ import print_function
+import sys, os
+
+
+# Instruction:
+# Script can be called from python interpreter
+# or aliased and used as any other UNIX tools,
+# like 'cd' or 'cat'.
+#
+# In order to use this script like 'UNIX tool':
+# $ chmod +x jfmt.py
+# And add alias to your profile or rc file:
+# alias jfmt="~/path/to/jfmt.py"
+#
+#
+# Behaviour:
+# When script called in directory without arguments,
+# or on directory it will format every .java file
+# in current (or provided) directory AND child directories.
+# 
+# When script called with argument which is path to .java
+# file, only this file will be formated.
+
+
+# Get script location path in order to find
+# a real path of the google-java-format.
+def origin_path():
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
+
+# Constants:
+# Command which will be executed by the os.system()
+GJF = "google-java-format-1.0-all-deps.jar"
+COMMAND = "java -jar " + origin_path() + "/" + GJF
+# Verbose output.
+DEBUG = False
+
+def format_files(p):
+    '''
+    Format files in `p` directory.
+    '''
+    for (dirpath, dnames, fnames) in os.walk(p):
+        for fname in fnames:
+            if fname.endswith('.java'):
+                fpath = dirpath + '/' + fname
+                c = COMMAND + " --replace " + fpath
+                os.system(c)
+                if DEBUG:
+                    print("Path: ", dirpath)
+                    print("Name: ", fname)
+
+def format_file(p):
+    '''
+    Format the file.
+    '''
+    c = COMMAND + " --replace " + p
+    os.system(c)
+
+def parse_argv():
+    if len(sys.argv) == 2:
+        p = os.path.abspath(sys.argv[1])
+        if os.path.isfile(p):
+            format_file(p)
+        if os.path.isdir(p):
+            format_files(p)
+    if len(sys.argv) == 1:
+        p = os.getcwd()
+        format_files(p)
+
+def print_help(reason):
+    if reason == "jar":
+        print("ERROR: No " + GJF + " found")
+        print("\nIn order to use 'jfmt' you need to put " +
+              "'google-java-format-1.0-all-deps.jar' into the folder " +
+              "with 'jfmt' script.\n")
+
+def check_source():
+    '''
+    Check is google-java-format is present or not.
+    '''
+    o = origin_path()
+    p = o + "/" + GJF
+    if os.path.isfile(p):
+        return True
+    else:
+        return False
+
+def main():
+    if check_source():
+        print("Processing...")
+        parse_argv()
+        print("Done.")
+    else:
+        print_help("jar")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/jfmt.py
+++ b/scripts/jfmt.py
@@ -4,10 +4,14 @@ from __future__ import print_function
 import sys, os
 
 
+# Purpose:
+# Format all .java files in the directory, including child
+# directories and their .java files, or just a single .java
+# file.
+#
 # Instruction:
-# Script can be called from python interpreter
-# or aliased and used as any other UNIX tools,
-# like 'cd' or 'cat'.
+# Script can be called from python interpreter or aliased
+# and used as any other UNIX tools, like 'cd' or 'cat'.
 #
 # In order to use this script like 'UNIX tool':
 # $ chmod +x jfmt.py
@@ -16,9 +20,9 @@ import sys, os
 #
 #
 # Behaviour:
-# When script called in directory without arguments,
-# or on directory it will format every .java file
-# in current (or provided) directory AND child directories.
+# When script called in directory without arguments, or on
+# directory it will format every .java file in current
+# (or provided) directory AND child directories.
 # 
 # When script called with argument which is path to .java
 # file, only this file will be formated.


### PR DESCRIPTION
I wrote a tool, Python script, which is able to format .java files in directory and subdirectories or just a single .java file. I use it like `$ jfmt /path/to/project/dir` and I find it very convenient way to format my code as a whole.

Script was tested on Linux and Mac.

I hope this tool can be useful for others. Also, I not quite sure about the name. I was inspired by `fmt` from the Go lang.
