### PR TITLE
Expose max length to JavaFormatterOptions builder

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -62,13 +62,16 @@ public class JavaFormatterOptions {
 
   private final Style style;
 
-  private JavaFormatterOptions(Style style) {
+  private final int maxLineLength;
+
+  private JavaFormatterOptions(Style style, int maxLineLength) {
     this.style = style;
+    this.maxLineLength = maxLineLength;
   }
 
   /** Returns the maximum formatted width */
   public int maxLineLength() {
-    return DEFAULT_MAX_LINE_LENGTH;
+    return maxLineLength;
   }
 
   /** Returns the multiplier for the unit of indent */
@@ -89,6 +92,7 @@ public class JavaFormatterOptions {
   /** A builder for {@link JavaFormatterOptions}. */
   public static class Builder {
     private Style style = Style.GOOGLE;
+    private int maxLineLength = DEFAULT_MAX_LINE_LENGTH;
 
     private Builder() {}
 
@@ -97,8 +101,13 @@ public class JavaFormatterOptions {
       return this;
     }
 
+    public Builder maxLineLength(int maxLineLength) {
+      this.maxLineLength = maxLineLength;
+      return this;
+    }
+
     public JavaFormatterOptions build() {
-      return new JavaFormatterOptions(style);
+      return new JavaFormatterOptions(style, maxLineLength);
     }
   }
 }


### PR DESCRIPTION
For my googleformatter-maven-plugin I allow for customised line lengths, which is no longer possible with the current SNAPSHOT API ( I used to have a subclass that overloaded the `getMaxLineLength()` method.

The `JavaFormatterOptions` class lists a `DEFAULT_MAX_LINE_LENGTH` but it's not actually customisable.

This patch simply exposes that to the `Builder`.

NB: I've not currently signed any CLA's for Google - what ( if any ) is the process there?
