### PR TITLE
Support running formatter thru a Maven plugin

### DIFF
--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -1,0 +1,40 @@
+# Google Java Format Maven Plugin
+
+## Usage
+
+The plugin can be configured in the `build` section:
+
+```xml
+<plugin>
+	<groupId>com.google.goolejavaformat</groupId>
+	<artifactId>google-java-format-maven-plugin</artifactId>
+	<version>RELEASE</version>
+	<configuration>
+		<failOnError>false</failOnError>
+		<style>google</style>
+	</configuration>
+	<executions>
+		<execution>
+			<id>default</id>
+			<phase>process-sources</phase>
+			<goals>
+				<goal>format</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+```
+
+## Build
+
+To build the plugin
+
+```bash
+$ mvn clean install
+```
+
+and to apply it against itself
+
+```bash
+$ mvn verify -Prun-self
+```

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,0 +1,114 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<prerequisites>
+		<maven>3.3.0</maven>
+	</prerequisites>
+
+	<parent>
+		<groupId>com.google.googlejavaformat</groupId>
+		<artifactId>google-java-format-parent</artifactId>
+		<version>1.1-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>google-java-format-maven-plugin</artifactId>
+	<packaging>maven-plugin</packaging>
+
+	<name>Google Java Format Maven Plugin</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<version.maven-annotations>3.4</version.maven-annotations>
+		<version.maven-api>3.3.3</version.maven-api>
+		<version.maven-project>2.2.1</version.maven-project>
+		<version.plexus>3.0.8</version.plexus>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-plugin-api</artifactId>
+			<version>${version.maven-api}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>${version.maven-annotations}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.codehaus.plexus</groupId>
+			<artifactId>plexus-utils</artifactId>
+			<version>${version.plexus}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-project</artifactId>
+			<version>${version.maven-project}</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.google.googlejavaformat</groupId>
+			<artifactId>google-java-format</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.4</version>
+				<configuration>
+					<goalPrefix>google-java-format</goalPrefix>
+					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+				</configuration>
+				<executions>
+					<execution>
+						<id>mojo-descriptor</id>
+						<goals>
+							<goal>descriptor</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>help-goal</id>
+						<goals>
+							<goal>helpmojo</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>run-self</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>com.google.googlejavaformat</groupId>
+						<artifactId>${project.artifactId}</artifactId>
+						<version>${project.version}</version>
+						<executions>
+							<execution>
+								<id>format-sources</id>
+								<phase>process-sources</phase>
+								<inherited>false</inherited>
+								<goals>
+									<goal>format</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+</project>

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/CollectingFileVisitor.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/CollectingFileVisitor.java
@@ -1,0 +1,60 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.Iterators;
+
+/**
+ * An implementation of {@link FileVisitor} that collects all the visited files that have a specific
+ * extension.
+ *
+ * <p>TODO: Suggestion: Move to API?
+ */
+class CollectingFileVisitor extends SimpleFileVisitor<Path> {
+  private final Set<Path> collectedFiles;
+  private final String extension;
+
+  /**
+   * Creates an instance.
+   *
+   * @param collectedFiles the {@link Set} to hold the {@link Path} to files being collected
+   * @param extension the expected extension
+   */
+  public CollectingFileVisitor(final Set<Path> collectedFiles, final String extension) {
+    Objects.requireNonNull(collectedFiles);
+    this.collectedFiles = collectedFiles;
+    this.extension = extension;
+  }
+
+  @Override
+  public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+    if (Iterators.size(Files.newDirectoryStream(dir).iterator()) == 0) {
+      return FileVisitResult.SKIP_SUBTREE;
+    }
+    return super.preVisitDirectory(dir, attrs);
+  }
+
+  @Override
+  public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+    if (matchesExtension(file)) {
+      addPath(file);
+    }
+    return super.visitFile(file, attrs);
+  }
+
+  protected void addPath(Path file) {
+    this.collectedFiles.add(file);
+  }
+
+  protected boolean matchesExtension(Path file) {
+    return file.getFileName().toString().endsWith(extension);
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/Executor.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/Executor.java
@@ -1,0 +1,46 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import com.google.common.collect.Lists;
+
+/** A utility class around {@link ExecutorService} to execute and collect results. */
+class Executor {
+
+  /**
+   * Execute a {@link List} of {@link Callable} tasks and wait for the results to collect them or
+   * fail as soon as one fails. An {@link ExecutorService} is created and shut down; when shutting
+   * down the executor service, the unfinished tasks by {@link ExecutorService#shutdownNow()} is
+   * ignored.
+   *
+   * @param <T> the type of expected results
+   * @param <C> the bound type for task implementing {@link Callable} of {@code T}
+   * @param tasks the {@link List} of tasks as instances of {@link Callable}
+   * @return the {@link List} of result values collected from {@link Future}'s
+   * @throws InterruptedException thrown if the execution is interrupted
+   * @throws ExecutionException thrown if a task fails during processing
+   */
+  static <T, C extends Callable<T>> List<T> execute(List<C> tasks)
+      throws InterruptedException, ExecutionException {
+    // Use at most half of the available processors from runtime not to consume too many resources
+    final ExecutorService executor =
+        Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() / 2 + 1);
+    try {
+      // #invokeAll preserves the order of submitted tasks in the returned futures
+      List<Future<T>> taskResults = executor.invokeAll(tasks);
+      List<T> results = Lists.newLinkedList();
+      for (Future<T> f : taskResults) {
+        results.add(f.get());
+      }
+      return Collections.unmodifiableList(results);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FileCollector.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FileCollector.java
@@ -1,0 +1,96 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.io.IOException;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+/**
+ * Helps collecting Java source files during the mojo execution.
+ *
+ * <p>This class is essentially a function of {@link Path} to {@link List} of {@link Path}. The
+ * implementation does not reflect that just in case for backward compatibility with old Java
+ * versions.
+ *
+ * <p>TODO: Suggestion: Move to API? It can be used later in the core collect all the Java source
+ * files if the input parameter to CLI is a directory.
+ *
+ * @see #collect(Path)
+ */
+class FileCollector {
+
+  /**
+   * Concurrently collects all the files with provided {@code extension} from the list of paths.
+   *
+   * @param paths the {@link List} of {@link Path} to collect files from
+   * @param extension the extension to match with when collecting files
+   * @return a {@link List} of collected files
+   * @throws InterruptedException thrown if the concurrent execution is interrupted
+   * @throws ExecutionException thrown if execution fails processing a directory or a file
+   */
+  static List<Path> collectAll(List<Path> paths, String extension)
+      throws InterruptedException, ExecutionException {
+    List<FileCollectorTask> fileCollectorTasks = createFileCollectorTasks(paths, extension);
+    List<List<Path>> collectedPaths = Executor.execute(fileCollectorTasks);
+    List<Path> allPaths = Lists.newLinkedList();
+    for (List<Path> pathList : collectedPaths) {
+      allPaths.addAll(pathList);
+    }
+    return Collections.unmodifiableList(allPaths);
+  }
+
+  /**
+   * Creates tasks for collecting files.
+   *
+   * @param paths the {@link List} of paths to collect files from.
+   * @param extension the extension of expected files
+   * @return a {@link List} of {@link FileCollectorTask}
+   */
+  static List<FileCollectorTask> createFileCollectorTasks(List<Path> paths, String extension) {
+    List<FileCollectorTask> tasks = Lists.newLinkedList();
+    for (Path path : paths) {
+      tasks.add(new FileCollectorTask(path, extension));
+    }
+    return tasks;
+  }
+
+  private final String extension;
+
+  /**
+   * C'tor.
+   *
+   * @param extension the expected extension for this file collector
+   */
+  public FileCollector(String extension) {
+    Objects.requireNonNull(extension);
+    this.extension = extension;
+  }
+
+  /**
+   * Collects files that have the expected extension from a specific directory path. This method
+   * uses {@link Files#walk(Path, java.nio.file.FileVisitOption...)} with an instance of {@link
+   * CollectingFileVisitor} to collect the files.
+   *
+   * @param path the directory path to collect files from
+   * @return the {@link List} of {@link Path} of collected files
+   * @throws IOException thrown if either the starting path is not directory, or there's a
+   *     processing error for a directory or path
+   */
+  public List<Path> collect(final Path path) throws IOException {
+    if (!Files.isDirectory(path)) {
+      throw new IOException("Path must be a directory: " + path);
+    }
+    final Set<Path> collectedFiles = Sets.newLinkedHashSet();
+    FileVisitor<Path> visitor = new CollectingFileVisitor(collectedFiles, extension);
+    Files.walkFileTree(path, visitor);
+    return Lists.newLinkedList(collectedFiles);
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FileCollectorTask.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FileCollectorTask.java
@@ -1,0 +1,24 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * A {@link Callable} implementation to execute {@link FileCollector#collect(Path)} as a task for
+ * concurrent execution.
+ */
+class FileCollectorTask implements Callable<List<Path>> {
+  private final Path path;
+  private final String extension;
+
+  public FileCollectorTask(Path path, String extension) {
+    this.path = path;
+    this.extension = extension;
+  }
+
+  @Override
+  public List<Path> call() throws Exception {
+    return new FileCollector(extension).collect(path);
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FormatMojo.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/FormatMojo.java
@@ -1,0 +1,179 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.googlejavaformat.java.Formatter;
+import com.google.googlejavaformat.java.FormatterException;
+import com.google.googlejavaformat.java.JavaFormatterOptions;
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+
+/**
+ * Applies coding style formatting on the Java sources in the configured Maven project using Google
+ * Java Format. Note that not all the command line options are available through this Maven plugin.
+ */
+@Mojo(
+  name = "format",
+  defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+  threadSafe = false,
+  aggregator = true,
+  requiresReports = false
+)
+public class FormatMojo extends AbstractMojo {
+
+  private static final String JAVA_SOURCE_EXTENSION = ".java";
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  /**
+   * The coding style to be applied to the sources of the project Java sources. The default style is
+   * {@value Style#GOOGLE}. The value is not case-sensitive.
+   */
+  @Parameter(defaultValue = "google", property = "gjf.style", required = false)
+  private String style;
+
+  /**
+   * Whether to fail the build or not when formatting the sources fail. The default is {@code
+   * false}. If the configuration is invalid, it always breaks the build.
+   */
+  @Parameter(defaultValue = "false", property = "gjf.failOnError", required = false)
+  private boolean failOnError = false;
+
+  /* (non-Javadoc)
+   * @see org.apache.maven.plugin.Mojo#execute()
+   */
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    final long start = System.currentTimeMillis();
+    List<String> sourceRoots = Lists.newArrayList();
+    sourceRoots.addAll(project.getCompileSourceRoots());
+    sourceRoots.addAll(project.getTestCompileSourceRoots());
+    format(sourceRoots, buildJavaFormatterOptions());
+    getLog().info("Formatting completed in " + (System.currentTimeMillis() - start) + "ms");
+  }
+
+  /**
+   * Runs {@link FormatterException} on the provided source roots. Java sources in the Maven project
+   * are <i>concurrently</i> collected. Formatting is also <i>concurrently</i> executed.
+   *
+   * @param sourceRoots the {@link List} of root of Java source directories
+   * @param javaFormatterOptions the options configured for the Maven plugin for {@link Formatter}
+   * @throws MojoExecutionException thrown if concurrent execution of collecting Java sources or
+   *     formatting fails, or an {@link IOException} when find Java sources or reading Java sources.
+   */
+  protected void format(List<String> sourceRoots, JavaFormatterOptions javaFormatterOptions)
+      throws MojoExecutionException {
+    try {
+      List<Path> sources = findJavaSources(sourceRoots);
+      getLog().info("Formatting " + sources.size() + " Java sources ...");
+      format(new Formatter(javaFormatterOptions), sources);
+    } catch (ExecutionException e) {
+      onException("Failed formatting sources: " + e.getCause().getMessage(), e.getCause());
+    } catch (InterruptedException e) {
+      onException("Formatting interrupted.", e);
+    } catch (IOException e) {
+      onException("I/O error during formatting: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Find all Java source files from a list of directories. A Java source file is presumed to have
+   * the extension {@code ".java"}.
+   *
+   * @param sourceRoots the {@link List} of directory paths to collect files from
+   * @return the {@link List} of collected Java source files
+   * @throws InterruptedException thrown if concurrent execution is interrupted
+   * @throws ExecutionException thrown as soon as an exception occurs in collecting Java sources
+   * @throws IOException thrown if a directory or file cannot be read
+   */
+  protected List<Path> findJavaSources(List<String> sourceRoots)
+      throws InterruptedException, ExecutionException, IOException {
+    List<Path> sources = Lists.newLinkedList();
+    for (String sourceRoot : sourceRoots) {
+      Path pathRoot = Paths.get(sourceRoot);
+      if (!Files.isDirectory(pathRoot)
+          || Iterators.size(Files.newDirectoryStream(pathRoot).iterator()) == 0) {
+        getLog().info("Skipping non-existing or empty directory: " + pathRoot);
+        continue;
+      }
+      sources.add(pathRoot);
+    }
+    return FileCollector.collectAll(sources, JAVA_SOURCE_EXTENSION);
+  }
+
+  /**
+   * Build {@link JavaFormatterOptions} based on configuration. The build always fails if the
+   * configuration is not valid regardless if {@code failOnError} is {@code false}.
+   *
+   * @return an instance of {@link JavaFormatterOptions}
+   * @throws MojoExecutionException thrown if the configuration is invalid
+   */
+  protected JavaFormatterOptions buildJavaFormatterOptions() throws MojoExecutionException {
+    try {
+      return JavaFormatterOptions.builder().style(Style.valueOf(this.style.toUpperCase())).build();
+    } catch (Exception e) {
+      throw new MojoExecutionException("Invalid configuration: ", e);
+    }
+  }
+
+  /**
+   * Runs the formatter against all the given source files.
+   *
+   * @param formatter the {@link Formatter} instance
+   * @param sources the {@link List} of Java source {@link Path}s
+   * @throws InterruptedException thrown if the concurrent execution of formatting is interrupted
+   * @throws ExecutionException thrown as soon as formatting fails for one of the source files
+   */
+  protected void format(Formatter formatter, List<Path> sources)
+      throws InterruptedException, ExecutionException {
+    List<SourceFileFormatTask> sourceFileFormatTasks =
+        createSourceFileFormatTasks(sources, formatter);
+    Executor.execute(sourceFileFormatTasks);
+  }
+
+  /**
+   * Create a list of formatting tasks for concurrent execution of {@link Formatter}.
+   *
+   * @param sources the {@link List} of Java source {@link Path}s
+   * @param formatter the {@link Formatter} instance
+   * @return a {@link List} of {@link SourceFileFormatTask}
+   */
+  protected List<SourceFileFormatTask> createSourceFileFormatTasks(
+      List<Path> sources, Formatter formatter) {
+    List<SourceFileFormatTask> tasks = Lists.newLinkedList();
+    for (Path source : sources) {
+      tasks.add(new SourceFileFormatTask(source, formatter));
+    }
+    return tasks;
+  }
+
+  /**
+   * Checks if {@code failOnError} and either throws an instance of {@link MojoExecutionException}
+   * or just logs a message without breaking the build.
+   *
+   * @param logMessage the message to log
+   * @param e the exception to be thrown as the cause
+   * @throws MojoExecutionException thrown to break the build and contains the cause of failure
+   */
+  protected void onException(String logMessage, Throwable e) throws MojoExecutionException {
+    if (failOnError) {
+      throw new MojoExecutionException(logMessage, e);
+    } else {
+      getLog().error(logMessage);
+    }
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/JavaSourceFormatter.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/JavaSourceFormatter.java
@@ -1,0 +1,70 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.google.googlejavaformat.java.Formatter;
+import com.google.googlejavaformat.java.FormatterException;
+
+/**
+ * Simplifies formatting Java source files. See {@link #format()}.
+ *
+ * <p>TODO: Suggestion: Candidate to move to API?
+ */
+class JavaSourceFormatter {
+  private final Path source;
+  private final boolean replace;
+  private final Formatter formatter;
+
+  /**
+   * Creates an instance that replaces the original source by the formatted source.
+   *
+   * @param source the {@link Path} to the Java source file
+   * @param formatter the {@link Formatter} instance to use
+   */
+  JavaSourceFormatter(Path source, Formatter formatter) {
+    this(source, formatter, true);
+  }
+
+  /**
+   * Creates an instance.
+   *
+   * @param source the {@link Path} to the Java source file
+   * @param formatter the {@link Formatter} instance to use
+   * @param replace if the original source file should be replaced with the formatted source
+   */
+  JavaSourceFormatter(Path source, Formatter formatter, final boolean replace) {
+    this.source = source;
+    this.formatter = formatter;
+    this.replace = replace;
+  }
+
+  /**
+   * Reads the Java source file using {@link Files#readAllBytes(Path)}, uses {@link
+   * Formatter#formatSource(String)}, and finally if configured to replace, then writes the
+   * formatted source to the source file using {@link Files#write(Path, byte[],
+   * java.nio.file.OpenOption...)}.
+   *
+   * @return the formatted source
+   * @throws IOException thrown if reading/writing from/to the source file fails
+   * @throws FormatterException See {@link Formatter#formatSource(String)}
+   */
+  public String format() throws IOException, FormatterException {
+    String sourceChars = read();
+    String formattedSource = formatter.formatSource(sourceChars);
+    if (replace) {
+      write(formattedSource);
+    }
+    return formattedSource;
+  }
+
+  protected void write(String formattedSource) throws IOException {
+    Files.write(source, formattedSource.getBytes(StandardCharsets.UTF_8));
+  }
+
+  protected String read() throws IOException {
+    return new String(Files.readAllBytes(this.source), StandardCharsets.UTF_8);
+  }
+}

--- a/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/SourceFileFormatTask.java
+++ b/maven-plugin/src/main/java/com/google/googlejavaformat/java/maven/SourceFileFormatTask.java
@@ -1,0 +1,31 @@
+package com.google.googlejavaformat.java.maven;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import com.google.googlejavaformat.java.Formatter;
+
+/**
+ * An implementation of {@link Callable} that enables executing {@link JavaSourceFormatter} as a
+ * task in a concurrent way.
+ */
+class SourceFileFormatTask implements Callable<String> {
+  private final Path source;
+  private final Formatter formatter;
+
+  /**
+   * Creates an instance.
+   *
+   * @param source the {@link Path} to Java source file
+   * @param formatter the {@link Formatter} instance
+   */
+  public SourceFileFormatTask(Path source, Formatter formatter) {
+    this.source = source;
+    this.formatter = formatter;
+  }
+
+  @Override
+  public String call() throws Exception {
+    return new JavaSourceFormatter(source, formatter).format();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 
   <modules>
     <module>core</module>
+    <module>maven-plugin</module>
     <!-- google-java-format#24
     <module>idea_plugin</module>
     -->


### PR DESCRIPTION
Not all the CLI options are available. Configuration parameters
include 'style' and 'failOnError'. Refer to README.md for usage.

This is an alpha version. It brings a few TODO points as suggestions
to be added to core API. Configurations can be extended to allow
for example `excludes` and `includes`.

The plugin defines a profile 'run-self' to apply formatting to the
plugin source itself. To run first `mvn install` then `mvn verify -Prun-self`.

For context and discussion, please refer to #69
