### PR TITLE
Maintain double spaces after periods and colons

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocLexer.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocLexer.java
@@ -255,7 +255,9 @@ final class JavadocLexer {
    * but in the course of joining literals, we incidentally join whitespace, too. We do take
    * advantage of the joining later on: It simplifies {@link #inferParagraphTags}.
    *
-   * <p>Note that we do <i>not</i> merge a literal token and a whitespace token together.
+   * <p>Note that we do <i>not</i> merge a literal token and a whitespace token together, except in
+   * special cases such as when the following literal starts with "@" or the preceding literal ends
+   * with ".".
    */
   private static ImmutableList<Token> joinAdjacentLiteralsAndAdjacentWhitespace(List<Token> input) {
     /*
@@ -275,13 +277,6 @@ final class JavadocLexer {
         continue;
       }
 
-      /*
-       * IF we have accumulated some literals to join together (say, "foo<b>bar</b>"), and IF we'll
-       * next see whitespace followed by a "@" literal, we need to join that together with the
-       * previous literals. That ensures that we won't insert a line break before the "@," turning
-       * it into a tag.
-       */
-
       if (accumulated.length() == 0) {
         output.add(tokens.peek());
         tokens.next();
@@ -293,8 +288,37 @@ final class JavadocLexer {
         seenWhitespace.append(tokens.next().getValue());
       }
 
-      if (tokens.peek().getType() == LITERAL && tokens.peek().getValue().startsWith("@")) {
-        // OK, we're in the case described above.
+      /*
+       * The next two if statements handle special cases: merge two literal tokens, together with
+       * the whitespace that separates them.
+       */
+
+      /*
+       * If the programmer uses two spaces after a period or colon, preserve that.  This also
+       * prevents a line from ending with a period or colon, which would make it impossible to know
+       * the programmer's preference regarding how many spaces should follow it.
+       */
+
+      char accumulatedEnd = accumulated.charAt(accumulated.length() - 1);
+      if (!isParagraphBreak(seenWhitespace.toString())
+          && tokens.peek().getType() == LITERAL
+          && (accumulatedEnd == '.' || accumulatedEnd == ':')) {
+        accumulated.append(seenWhitespace.toString().startsWith("  ") ? "  " : " ");
+        accumulated.append(tokens.peek().getValue());
+        tokens.next();
+        continue;
+      }
+
+      /*
+       * IF we have accumulated some literals to join together (say, "foo<b>bar</b>"), and IF we'll
+       * next see whitespace followed by a "@" literal, we need to join that together with the
+       * previous literals. That ensures that we won't insert a line break before the "@," turning
+       * it into a tag.
+       */
+
+      if (!isParagraphBreak(seenWhitespace.toString())
+          && tokens.peek().getType() == LITERAL
+          && tokens.peek().getValue().startsWith("@")) {
         accumulated.append(" ");
         accumulated.append(tokens.peek().getValue());
         tokens.next();
@@ -316,6 +340,11 @@ final class JavadocLexer {
      * /[^ -]-/, as in "non-\nblocking."
      */
     return output.build();
+  }
+
+  /** Returns true if {@code whitespace} contains two newlines. */
+  private static boolean isParagraphBreak(String whitespace) {
+    return whitespace.indexOf('\n') != whitespace.lastIndexOf('\n');
   }
 
   /**

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/SentenceEnding.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/SentenceEnding.input
@@ -1,0 +1,12 @@
+/**
+ * This is a sentence.  Two spaces between sentences
+ * makes them easier to read.  Maintaining the current
+ * spacing is preferable to discarding it.
+ * At the end of a line, we have to make a guess.
+ * That is undesirable, but a person can edit the
+ * comment to prevent sentences from ending at the
+ * end of a line.  Or, there could be a command-line
+ * option to control how much space to add
+ * after a line-ending period.
+ */
+class SentenceEnding {}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/SentenceEnding.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/SentenceEnding.output
@@ -1,0 +1,8 @@
+/**
+ * This is a sentence.  Two spaces between sentences makes them easier to read.  Maintaining the
+ * current spacing is preferable to discarding it. At the end of a line, we have to make a
+ * guess. That is undesirable, but a person can edit the comment to prevent sentences from ending at
+ * the end of a line.  Or, there could be a command-line option to control how much space to add
+ * after a line-ending period.
+ */
+class SentenceEnding {}


### PR DESCRIPTION
This pull request fixes issue #62.  It respects the spacing written by the programmer after periods and colons.
