### PR TITLE
Silently skip `module-info.java`

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -119,6 +119,10 @@ public final class Main {
         errWriter.println("Skipping non-Java file: " + fileName);
         continue;
       }
+      // https://github.com/google/google-java-format/issues/75
+      if (fileName.endsWith("module-info.java")) {
+        continue;
+      }
       Path path = Paths.get(fileName);
       String input;
       try {


### PR DESCRIPTION
Silently skip `module-info.java` until it's syntax is supported. Solution 1 from #75
