### PR TITLE
Auto detect line separator from input and use it in output.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/LineSeparator.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/LineSeparator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.googlejavaformat.java;
+
+import java.util.regex.Pattern;
+
+/**
+ * Line separator constants and utilities.
+ */
+public enum LineSeparator {
+
+  /**
+   * Windows line separator: CRLF or as String {@code "\r\n"}.
+   */
+  WINDOWS("\r\n", Pattern.compile("(?s).*(\\r\\n).*")),
+
+  /**
+   * Unix/Linux line separator: LF or as a String {@code "\n"}.
+   */
+  UNIX("\n", Pattern.compile("(?s).*(\\n).*")),
+
+  /**
+   * Legacy Mac OS line separator: CR or as a String {@code "\r"}.
+   */
+  MAC("\r", Pattern.compile("(?s).*(\\r).*"));
+
+  /**
+   * Convenient for {@code detect(text, LineSeparator.UNIX)}.
+   */
+  public static LineSeparator detect(String text) {
+    return detect(text, UNIX);
+  }
+
+  /**
+   * Identify which line delimiter is used by the underlying text.
+   *
+   * <p>The enum constants are iterated in declaration order by this implementation. That means for
+   * texts using mixed separators, the first hit determines the returned separator of this method.
+   *
+   * <p>If no pattern matches, the passed default separator is returned.
+   */
+  public static LineSeparator detect(String text, LineSeparator defaultSeparator) {
+    for (LineSeparator separator : values()) {
+      if (separator.pattern.matcher(text).matches()) {
+        return separator;
+      }
+    }
+    return defaultSeparator;
+  }
+
+  private final String chars;
+  private final Pattern pattern;
+
+  LineSeparator(String chars, Pattern pattern) {
+    this.chars = chars;
+    this.pattern = pattern;
+  }
+
+  public String getChars() {
+    return chars;
+  }
+
+  /**
+   * Converts the given text by replacing all line separators with this line separator chars.
+   *
+   * <p>For the sake of speed, conversion result of texts using mixed line separators are not
+   * always the same. Only a single pattern is replaced with this line separator chars.
+   *
+   * @param text to convert
+   * @return the converted text
+   */
+  public String convert(String text) {
+    return convert(text, detect(text));
+  }
+
+  String convert(String text, LineSeparator lineSeparatorUsedInText) {
+    if (this == lineSeparatorUsedInText) {
+      return text;
+    }
+    return text.replace(lineSeparatorUsedInText.chars, this.chars);
+  }
+
+  /** Predicate function comparing this with the result of {@link #detect(String)}. */
+  public boolean matches(String text) {
+    return this == detect(text);
+  }
+}

--- a/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
@@ -52,6 +52,7 @@ import org.eclipse.jdt.core.dom.Type;
  * Removes unused imports from a source file. Imports that are only used in javadoc are also
  * removed, and the references in javadoc are replaced with fully qualified names.
  */
+@SuppressWarnings("unchecked") // jdt uses raw types extensively
 public class RemoveUnusedImports {
 
   /** Configuration for javadoc-only imports. */
@@ -209,7 +210,7 @@ public class RemoveUnusedImports {
       // delete the import
       int endPosition = importTree.getStartPosition() + importTree.getLength();
       endPosition = Math.max(CharMatcher.isNot(' ').indexIn(contents, endPosition), endPosition);
-      String sep = System.lineSeparator();
+      String sep = "\n"; // don't use System.lineSeparator() - here we're always in Unix-land
       if (endPosition + sep.length() < contents.length()
           && contents.subSequence(endPosition, endPosition + sep.length()).equals(sep)) {
         endPosition += sep.length();

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
@@ -16,8 +16,10 @@ package com.google.googlejavaformat.java;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.fail;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Range;
 import com.google.common.io.CharStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -308,5 +311,17 @@ public final class FormatterTest {
   public void stringEscapeLength() throws Exception {
     assertThat(new Formatter().formatSource("class T {{ f(\"\\\"\"); }}"))
         .isEqualTo("class T {\n  {\n    f(\"\\\"\");\n  }\n}\n");
+  }
+
+  @Test
+  public void nonUnixStyleFails() throws Exception {
+    String win = "class T {\r\n}\r\n";
+    try {
+      new Formatter().formatSource(win, Collections.singleton(Range.closedOpen(0, win.length())));
+      fail("Windows-style line separator should fail!");
+    } catch (IllegalArgumentException exception) {
+      assertThat(exception)
+          .hasMessage("Expected input with Unix-style line separator, but got: WINDOWS");
+    }
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
@@ -1273,13 +1273,13 @@ public final class JavadocFormattingTest {
   }
 
   @Test
-  public void windowsLineSeparator() throws FormatterException {
+  public void lineSeparator() throws FormatterException {
     String[] input = {
       "/**", " * hello", " *", " * <p>world", " */", "class Test {}",
     };
-    for (String separator : Arrays.asList("\r", "\r\n")) {
+    for (String separator : Arrays.asList("\r", "\r\n", "\n")) {
       String actual = formatter.formatSource(Joiner.on(separator).join(input));
-      assertThat(actual).isEqualTo(Joiner.on('\n').join(input) + "\n");
+      assertThat(actual).isEqualTo(Joiner.on(separator).join(input) + separator);
     }
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/LineSeparatorTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/LineSeparatorTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.googlejavaformat.java;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.googlejavaformat.java.LineSeparator.MAC;
+import static com.google.googlejavaformat.java.LineSeparator.UNIX;
+import static com.google.googlejavaformat.java.LineSeparator.WINDOWS;
+import static com.google.googlejavaformat.java.LineSeparator.detect;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Joiner;
+import java.io.ByteArrayInputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link LineSeparator}
+ */
+@RunWith(JUnit4.class)
+public class LineSeparatorTest {
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void detectEmptyTextReturnsDefaultSeparator() throws Exception {
+    assertThat(detect("")).isEqualTo(UNIX);
+    assertThat(detect("", WINDOWS)).isEqualTo(WINDOWS);
+    assertThat(detect("", UNIX)).isEqualTo(UNIX);
+    assertThat(detect("", MAC)).isEqualTo(MAC);
+  }
+
+  @Test
+  public void detectWindowsSeparator() throws Exception {
+    assertThat(detect("hello\r\nworld")).isEqualTo(WINDOWS);
+    assertThat(detect("hello\r\nworld\r\n")).isEqualTo(WINDOWS);
+    assertThat(WINDOWS.matches("hello\r\nworld")).isTrue();
+    assertThat(WINDOWS.matches("hello\r\nworld\r\n")).isTrue();
+  }
+
+  @Test
+  public void detectUnixSeparator() throws Exception {
+    assertThat(detect("hello\nworld")).isEqualTo(UNIX);
+    assertThat(detect("hello\nworld\n")).isEqualTo(UNIX);
+    assertThat(UNIX.matches("hello\nworld")).isTrue();
+    assertThat(UNIX.matches("hello\nworld\n")).isTrue();
+  }
+
+  @Test
+  public void detectMacSeparator() throws Exception {
+    assertThat(detect("hello\rworld")).isEqualTo(MAC);
+    assertThat(detect("hello\rworld\r")).isEqualTo(MAC);
+    assertThat(MAC.matches("hello\rworld")).isTrue();
+    assertThat(MAC.matches("hello\rworld\r")).isTrue();
+  }
+
+  @Test
+  public void detectSeparatorOfMixed() throws Exception {
+    assertThat(detect("hello\r\nworld\n")).isEqualTo(WINDOWS);
+    assertThat(detect("hello\rworld\r\n")).isEqualTo(WINDOWS);
+    assertThat(detect("hello\rworld\n")).isEqualTo(UNIX);
+    assertThat(detect("hello\nworld\r")).isEqualTo(UNIX);
+  }
+
+  @Test
+  public void convertEmptyTextStaysEmpty() throws Exception {
+    assertThat(WINDOWS.convert("")).isEmpty();
+    assertThat(UNIX.convert("")).isEmpty();
+    assertThat(MAC.convert("")).isEmpty();
+  }
+
+  @Test
+  public void convertToWindows() throws Exception {
+    convert123(WINDOWS, "1\r\n2\r\n3\r\n");
+  }
+
+  @Test
+  public void convertToUnix() throws Exception {
+    convert123(UNIX, "1\n2\n3\n");
+  }
+
+  @Test
+  public void convertToMac() throws Exception {
+    convert123(MAC, "1\r2\r3\r");
+  }
+
+  private void convert123(LineSeparator target, String expected) {
+    assertThat(target.convert("1\n2\n3\n")).isEqualTo(expected);
+    assertThat(target.convert("1\r2\r3\r")).isEqualTo(expected);
+    assertThat(target.convert("1\r\n2\r\n3\r\n")).isEqualTo(expected);
+  }
+
+  @Test
+  public void preserveLineSeparators() throws Exception {
+    String[] input = {
+        "import java.util.ArrayList;",
+        "class Test {",
+        "ArrayList<String> a = new ArrayList<>();",
+        "ArrayList<String> b = new ArrayList<>();",
+        "char c = '\\n';",
+        "}",
+    };
+    String[] expected = {
+        "import java.util.ArrayList;",
+        "",
+        "class Test {",
+        "  ArrayList<String> a = new ArrayList<>();",
+        "  ArrayList<String> b = new ArrayList<>();",
+        "  char c = '\\n';",
+        "}",
+        ""
+    };
+    for (LineSeparator separator : LineSeparator.values()) {
+      Joiner joiner = Joiner.on(separator.getChars());
+      String source = joiner.join(input);
+      assertThat(detect(source)).isSameAs(separator);
+      // stdin
+      StringWriter out = new StringWriter();
+      Main main =
+          new Main(
+              new PrintWriter(out, true),
+              new PrintWriter(System.err, true),
+              new ByteArrayInputStream(source.getBytes(UTF_8)));
+      assertThat(main.format("-")).isEqualTo(0);
+      assertThat(detect(out.toString())).isSameAs(separator);
+      assertThat(out.toString()).isEqualTo(joiner.join(expected));
+      // entire file
+      Path path = testFolder.newFile("Test" + separator.name() + ".java").toPath();
+      Files.write(path, source.getBytes(UTF_8));
+      main =
+          new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in);
+      int errorCode = main.format("-replace", path.toAbsolutePath().toString());
+      assertThat(errorCode).named("Error Code").isEqualTo(0);
+      assertThat(detect(new String(Files.readAllBytes(path), UTF_8))).isSameAs(separator);
+    }
+  }
+
+  @Test
+  public void partialFormatting() throws Exception {
+    Path path = testFolder.newFile("Test.java").toPath();
+    Files.write(path, "class Test {\r\n\r\n}".getBytes(UTF_8));
+    Main main =
+        new Main(new PrintWriter(System.out, true), new PrintWriter(System.err, true), System.in);
+    int errorCode = main.format("-offset", "16", "-length", "1", path.toAbsolutePath().toString());
+    assertThat(errorCode).named("Error Code").isEqualTo(0);
+  }
+}


### PR DESCRIPTION
# Overview
Solves #33 by auto detecting line separator from input, potentially convert to U`\n`ix-style, format/fix/remove-used and revert conversion before output, if necessary.