### PR TITLE
Added a gradle plugin which supports google-java-format to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,22 @@ new Formatter().formatSource(source, output);
 Your starting point should be the instance methods of
 `com.google.googlejavaformat.java.Formatter`.
 
+#### Gradle via Spotless
+
+[Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-to-java-source-google-java-format) can apply `google-java-format` automatically to all java sources in a project, as well as apply other kinds of formatter to other kinds of files.
+
+```gradle
+plugins {
+  id 'com.diffplug.gradle.spotless' version '3.1.0'
+}
+
+spotless {
+  java {
+    googleJavaFormat()
+  }
+}
+```
+
 ## Building from source
 
     mvn install


### PR DESCRIPTION
Spotless is a general-purpose formatting plugin that can call out to various third-party formatters.  Just added support for google-java-format in Spotless issue #33: https://github.com/diffplug/spotless/issues/33

Spotless has been battle-tested by JUnit, figured it would be useful for gradle users who want to use google-java-format.
