### PR TITLE
Platform-independent output line separator rendering

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/Newlines.java
+++ b/core/src/main/java/com/google/googlejavaformat/Newlines.java
@@ -55,6 +55,19 @@ public class Newlines {
     return null;
   }
 
+  /**
+   * Returns the first line separator in the text, or {@code defaultLineSeparator} if the text does
+   * not contain a single line separator.
+   */
+  public static String guessLineSeparator(String text, String defaultLineSeparator) {
+    for (String b : BREAKS) {
+      if (text.contains(b)) {
+        return b;
+      }
+    }
+    return defaultLineSeparator;
+  }
+
   /** Returns true if the input contains any line breaks. */
   public static boolean containsBreaks(String text) {
     return CharMatcher.anyOf("\n\r").matchesAnyOf(text);

--- a/core/src/main/java/com/google/googlejavaformat/Output.java
+++ b/core/src/main/java/com/google/googlejavaformat/Output.java
@@ -21,6 +21,52 @@ import com.google.googlejavaformat.OpsBuilder.BlankLineWanted;
 
 /** An output from the formatter. */
 public abstract class Output extends InputOutput {
+
+  /** Newline mode used by output. */
+  public enum Separator {
+    /**
+     * Line separator used by input.
+     */
+    AS_IS(null),
+
+    /**
+     * System default separator.
+     *
+     * @see System#lineSeparator()
+     */
+    DEFAULT(System.lineSeparator()),
+
+    /**
+     * Legacy Mac OS line separator: CR or as a String {@code "\r"}.
+     */
+    MAC("\r"),
+
+    /**
+     * Unix/Linux line separator: LF or as a String {@code "\n"}.
+     */
+    UNIX("\n"),
+
+    /**
+     * Windows line separator: CRLF or as String {@code "\r\n"}.
+     */
+    WINDOWS("\r\n");
+
+    private final String chars;
+
+    Separator(String chars) {
+      this.chars = chars;
+    }
+
+    /** Returns line separator char(s) to use. */
+    public String chars(String inputText) {
+      if (chars != null) {
+        return chars;
+      }
+      assert this == AS_IS;
+      return Newlines.guessLineSeparator(inputText, UNIX.chars);
+    }
+  }
+
   /** Unique identifier for a break. */
   public static final class BreakTag {
 

--- a/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
@@ -55,7 +55,7 @@ public class FormatFileCallable implements Callable<String> {
             parameters.removeJavadocOnlyImports()
                 ? JavadocOnlyImports.REMOVE
                 : JavadocOnlyImports.KEEP);
-    input = ImportOrderer.reorderImports(input);
+    input = ImportOrderer.reorderImports(input, options.outputSeparator().chars(input));
     return input;
   }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -232,8 +232,9 @@ public final class Formatter {
     // 'de-linting' changes (e.g. import ordering).
     input = ModifierOrderer.reorderModifiers(input, characterRanges);
 
+    String lineSeparator = options.outputSeparator().chars(input);
     JavaInput javaInput = new JavaInput(input);
-    JavaOutput javaOutput = new JavaOutput(javaInput, new JavaCommentsHelper(options));
+    JavaOutput javaOutput = new JavaOutput(lineSeparator, javaInput, new JavaCommentsHelper(options));
     try {
       format(javaInput, javaOutput, options);
     } catch (FormattingError e) {

--- a/core/src/main/java/com/google/googlejavaformat/java/ImportOrderer.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/ImportOrderer.java
@@ -22,6 +22,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
+import com.google.googlejavaformat.Newlines;
 import com.google.googlejavaformat.java.JavaInput.Tok;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 
@@ -33,7 +34,7 @@ public class ImportOrderer {
    *
    * @throws FormatterException if the input could not be parsed.
    */
-  public static String reorderImports(String text) throws FormatterException {
+  public static String reorderImports(String text, String lineSeparator) throws FormatterException {
     ImmutableList<Tok> toks;
     try {
       toks = JavaInput.buildToks(text, CLASS_START);
@@ -41,7 +42,7 @@ public class ImportOrderer {
       // error handling is done during formatting
       return text;
     }
-    return new ImportOrderer(text, toks).reorderImports();
+    return new ImportOrderer(text, lineSeparator, toks).reorderImports();
   }
 
   /**
@@ -61,9 +62,11 @@ public class ImportOrderer {
 
   private final String text;
   private final ImmutableList<Tok> toks;
+  private final String lineSeparator;
 
-  private ImportOrderer(String text, ImmutableList<Tok> toks) throws FormatterException {
+  private ImportOrderer(String text, String lineSeparator, ImmutableList<Tok> toks) {
     this.text = text;
+    this.lineSeparator = lineSeparator;
     this.toks = toks;
   }
 
@@ -242,7 +245,7 @@ public class ImportOrderer {
     for (Import thisImport : imports) {
       if (lastWasStatic && !thisImport.isStatic) {
         // Blank line between static and non-static imports.
-        sb.append('\n');
+        sb.append(lineSeparator);
       }
       lastWasStatic = thisImport.isStatic;
       sb.append(thisImport);

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -28,6 +28,7 @@ import java.util.List;
 public final class JavaCommentsHelper implements CommentsHelper {
 
   private final JavaFormatterOptions options;
+  private String lineSeparator = "\n"; // non-final, determined by rewrite
 
   public JavaCommentsHelper(JavaFormatterOptions options) {
     this.options = options;
@@ -39,6 +40,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
       return tok.getOriginalText();
     }
     String text = tok.getOriginalText();
+    this.lineSeparator = options.outputSeparator().chars(text);
     if (tok.isJavadocComment()) {
       text = JavadocFormatter.formatJavadoc(text, column0, options);
     }
@@ -58,7 +60,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
 
   // For non-javadoc-shaped block comments, shift the entire block to the correct
   // column, but do not adjust relative indentation.
-  private static String preserveIndentation(List<String> lines, int column0) {
+  private String preserveIndentation(List<String> lines, int column0) {
     StringBuilder builder = new StringBuilder();
 
     // find the leftmost non-whitespace character in all trailing lines
@@ -75,7 +77,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
 
     // output all trailing lines with plausible indentation
     for (int i = 1; i < lines.size(); ++i) {
-      builder.append("\n").append(Strings.repeat(" ", column0));
+      builder.append(lineSeparator).append(Strings.repeat(" ", column0));
       // check that startCol is valid index, e.g. for blank lines
       if (lines.get(i).length() >= startCol) {
         builder.append(lines.get(i).substring(startCol));
@@ -87,25 +89,25 @@ public final class JavaCommentsHelper implements CommentsHelper {
   }
 
   // Remove leading and trailing whitespace, and re-indent each line.
-  private static String indentLineComments(List<String> lines, int column0) {
+  private String indentLineComments(List<String> lines, int column0) {
     StringBuilder builder = new StringBuilder();
     builder.append(lines.get(0).trim());
     String indentString = Strings.repeat(" ", column0);
     for (int i = 1; i < lines.size(); ++i) {
-      builder.append("\n").append(indentString).append(lines.get(i).trim());
+      builder.append(lineSeparator).append(indentString).append(lines.get(i).trim());
     }
     return builder.toString();
   }
 
   // Remove leading and trailing whitespace, and re-indent each line.
   // Add a +1 indent before '*', and add the '*' if necessary.
-  private static String indentJavadoc(List<String> lines, int column0) {
+  private String indentJavadoc(List<String> lines, int column0) {
     StringBuilder builder = new StringBuilder();
     builder.append(lines.get(0).trim());
     int indent = column0 + 1;
     String indentString = Strings.repeat(" ", indent);
     for (int i = 1; i < lines.size(); ++i) {
-      builder.append("\n").append(indentString);
+      builder.append(lineSeparator).append(indentString);
       String line = lines.get(i).trim();
       if (!line.startsWith("*")) {
         builder.append("* ");

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -15,6 +15,7 @@
 package com.google.googlejavaformat.java;
 
 import com.google.errorprone.annotations.Immutable;
+import com.google.googlejavaformat.Output;
 
 /**
  * Options for a google-java-format invocation.
@@ -29,7 +30,9 @@ import com.google.errorprone.annotations.Immutable;
 @Immutable
 public class JavaFormatterOptions {
 
-  static final int DEFAULT_MAX_LINE_LENGTH = 100;
+  private static final int DEFAULT_MAX_LINE_LENGTH = 100;
+  private static final Style DEFAULT_STYLE = Style.GOOGLE;
+  private static final Output.Separator DEFAULT_OUTPUT_SEPARATOR = Output.Separator.AS_IS;
 
   public enum Style {
 
@@ -51,9 +54,11 @@ public class JavaFormatterOptions {
   }
 
   private final Style style;
+  private final Output.Separator outputSeparator;
 
-  private JavaFormatterOptions(Style style) {
-    this.style = style;
+  private JavaFormatterOptions(Builder builder) {
+    this.style = builder.style;
+    this.outputSeparator = builder.outputSeparator;
   }
 
   /** Returns the maximum formatted width */
@@ -64,6 +69,11 @@ public class JavaFormatterOptions {
   /** Returns the multiplier for the unit of indent */
   public int indentationMultiplier() {
     return style.indentationMultiplier();
+  }
+
+  /** Returns the line separator to use in output */
+  public Output.Separator outputSeparator() {
+    return outputSeparator;
   }
 
   /** Returns the default formatting options. */
@@ -78,7 +88,8 @@ public class JavaFormatterOptions {
 
   /** A builder for {@link JavaFormatterOptions}. */
   public static class Builder {
-    private Style style = Style.GOOGLE;
+    private Style style = DEFAULT_STYLE;
+    private Output.Separator outputSeparator = DEFAULT_OUTPUT_SEPARATOR;
 
     private Builder() {}
 
@@ -87,8 +98,13 @@ public class JavaFormatterOptions {
       return this;
     }
 
+    public Builder outputSeparator(Output.Separator outputSeparator) {
+      this.outputSeparator = outputSeparator;
+      return this;
+    }
+
     public JavaFormatterOptions build() {
-      return new JavaFormatterOptions(style);
+      return new JavaFormatterOptions(this);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInput.java
@@ -36,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
@@ -240,7 +239,6 @@ public final class JavaInput extends Input {
 
   private final String text; // The input.
   private int kN; // The number of numbered toks (tokens or comments), excluding the EOF.
-  private Map<Integer, Range<Integer>> kToI = null; // Map from token indices to line numbers.
 
   /*
    * The following lists record the sequential indices of the {@code Tok}s on each input line. (Only
@@ -516,54 +514,6 @@ public final class JavaInput extends Input {
       tokens.add(new Token(toksBefore.build(), tok, toksAfter.build()));
     }
     return tokens.build();
-  }
-
-  /**
-   * Returns the lowest line number the {@link Token} or one of its {@code tokBefore}s lies on in
-   * the {@code JavaInput}.
-   *
-   * @param token the {@link Token}
-   * @return the {@code 0}-based line number
-   */
-  int getLineNumberLo(Token token) {
-    int k = -1;
-    for (Tok tok : token.toksBefore) {
-      k = tok.getIndex();
-      if (k >= 0) {
-        break;
-      }
-    }
-    if (k < 0) {
-      k = token.tok.getIndex();
-    }
-    if (kToI == null) {
-      kToI = makeKToIJ(this, kN);
-    }
-    return kToI.get(k).lowerEndpoint();
-  }
-
-  /**
-   * Returns the highest line number the {@link Token} or one of its {@code tokAfter}s lies on in
-   * the {@code JavaInput}.
-   *
-   * @param token the {@link Token}
-   * @return the {@code 0}-based line number
-   */
-  int getLineNumberHi(Token token) {
-    int k = -1;
-    for (Tok tok : token.toksAfter.reverse()) {
-      k = tok.getIndex();
-      if (k >= 0) {
-        break;
-      }
-    }
-    if (k < 0) {
-      k = token.tok.getIndex();
-    }
-    if (kToI == null) {
-      kToI = makeKToIJ(this, kN);
-    }
-    return kToI.get(k).upperEndpoint() - 1;
   }
 
   /**

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
@@ -47,12 +47,8 @@ import java.util.Map;
  * methods to emit the output document.
  */
 public final class JavaOutput extends Output {
-  /** We merge untouched lines from the input with reformatted lines from the output. */
-  enum From {
-    INPUT,
-    OUTPUT
-  }
 
+  private final String lineSeparator; // Used to separate lines of code.
   private final JavaInput javaInput; // Used to follow along while emitting the output.
   private final CommentsHelper commentsHelper; // Used to re-flow comments.
   private final Map<Integer, BlankLineWanted> blankLines = new HashMap<>(); // Info on blank lines.
@@ -72,7 +68,8 @@ public final class JavaOutput extends Output {
    * @param javaInput the {@link JavaInput}, used to match up blank lines in the output
    * @param commentsHelper the {@link CommentsHelper}, used to rewrite comments
    */
-  public JavaOutput(JavaInput javaInput, CommentsHelper commentsHelper) {
+  public JavaOutput(String lineSeparator, JavaInput javaInput, CommentsHelper commentsHelper) {
+    this.lineSeparator = lineSeparator;
     this.javaInput = javaInput;
     this.commentsHelper = commentsHelper;
     kN = javaInput.getkN();
@@ -261,6 +258,7 @@ public final class JavaOutput extends Output {
       int replaceFrom = startTok.getPosition();
       while (replaceFrom > 0) {
         char previous = javaInput.getText().charAt(replaceFrom - 1);
+        // TODO Break also for '\r' and/or "\r\n"?
         if (previous == '\n') {
           break;
         }
@@ -273,7 +271,7 @@ public final class JavaOutput extends Output {
       }
 
       if (needsBreakBefore) {
-        replacement.append('\n');
+        replacement.append(lineSeparator);
       }
 
       boolean first = true;
@@ -287,12 +285,12 @@ public final class JavaOutput extends Output {
           if (first) {
             first = false;
           } else {
-            replacement.append('\n');
+            replacement.append(lineSeparator);
           }
           replacement.append(getLine(i));
         }
       }
-      replacement.append('\n');
+      replacement.append(lineSeparator);
 
       String trailingLine = i < getLineCount() ? getLine(i) : null;
 

--- a/core/src/test/java/com/google/googlejavaformat/java/ImportOrdererTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/ImportOrdererTest.java
@@ -378,7 +378,7 @@ public class ImportOrdererTest {
   @Test
   public void reorder() throws FormatterException {
     try {
-      String output = ImportOrderer.reorderImports(input);
+      String output = ImportOrderer.reorderImports(input, "\n");
       assertWithMessage("Expected exception").that(reordered).doesNotMatch("^!!");
       assertWithMessage(input).that(output).isEqualTo(reordered);
     } catch (FormatterException e) {

--- a/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
@@ -1279,7 +1279,7 @@ public final class JavadocFormattingTest {
     };
     for (String separator : Arrays.asList("\r", "\r\n")) {
       String actual = formatter.formatSource(Joiner.on(separator).join(input));
-      assertThat(actual).isEqualTo(Joiner.on('\n').join(input) + "\n");
+      assertThat(actual).isEqualTo(Joiner.on(separator).join(input) + separator);
     }
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
@@ -155,6 +155,7 @@ public class MainTest {
   // end to end import fixing test
   @Test
   public void imports() throws Exception {
+    Joiner joiner = Joiner.on(System.lineSeparator());
     String[] input = {
       "import java.util.LinkedList;",
       "import java.util.List;",
@@ -177,11 +178,11 @@ public class MainTest {
         "  public static List<String> names;",
         "}",
       };
-      InputStream in = new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8));
+      InputStream in = new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8));
       StringWriter out = new StringWriter();
       Main main = new Main(new PrintWriter(out, true), new PrintWriter(System.err, true), in);
       assertThat(main.format("-", "--fix-imports-only")).isEqualTo(0);
-      assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+      assertThat(out.toString()).isEqualTo(joiner.join(expected));
     }
     {
       String[] expected = {
@@ -191,19 +192,20 @@ public class MainTest {
         "  public static List<String> names;",
         "}",
       };
-      InputStream in = new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8));
+      InputStream in = new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8));
       StringWriter out = new StringWriter();
       Main main = new Main(new PrintWriter(out, true), new PrintWriter(System.err, true), in);
       assertThat(
               main.format("-", "--fix-imports-only", "--experimental-remove-javadoc-only-imports"))
           .isEqualTo(0);
-      assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+      assertThat(out.toString()).isEqualTo(joiner.join(expected));
     }
   }
 
   // test that -lines handling works with import removal
   @Test
   public void importRemovalLines() throws Exception {
+    Joiner joiner = Joiner.on(System.lineSeparator());
     String[] input = {
       "import java.util.ArrayList;",
       "import java.util.List;",
@@ -224,9 +226,9 @@ public class MainTest {
         new Main(
             new PrintWriter(out, true),
             new PrintWriter(System.err, true),
-            new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8)));
+            new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8)));
     assertThat(main.format("-", "-lines", "4")).isEqualTo(0);
-    assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+    assertThat(out.toString()).isEqualTo(joiner.join(expected));
   }
 
   // test that errors are reported on the right line when imports are removed

--- a/core/src/test/java/com/google/googlejavaformat/java/RemoveUnusedImportsTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/RemoveUnusedImportsTest.java
@@ -302,6 +302,8 @@ public class RemoveUnusedImportsTest {
         },
       },
     };
+    String lineSeparator = System.lineSeparator();
+    Joiner joiner = Joiner.on(lineSeparator);
     ImmutableList.Builder<Object[]> builder = ImmutableList.builder();
     for (String[][] inputAndOutput : inputsOutputs) {
       assertThat(inputAndOutput.length).isEqualTo(3);
@@ -309,9 +311,9 @@ public class RemoveUnusedImportsTest {
       String[] output = inputAndOutput[1];
       String[] outputFixJavadoc = inputAndOutput[2];
       String[] parameters = {
-        Joiner.on('\n').join(input) + '\n',
-        Joiner.on('\n').join(output) + '\n',
-        Joiner.on('\n').join(outputFixJavadoc) + '\n',
+        joiner.join(input) + lineSeparator,
+        joiner.join(output) + lineSeparator,
+        joiner.join(outputFixJavadoc) + lineSeparator,
       };
       builder.add(parameters);
     }


### PR DESCRIPTION
This PR implements the second step following-up from https://github.com/google/google-java-format/commit/4174d878b36159a8efec949e95531d6cc1276393 -- output is not longer hard-coded to use
LF.

- [x] Windows reports **green**: `Tests run: 1021, Failures: 0, Errors: 0, Skipped: 0`
- [x] Travis reports **green**: `Tests run: 1021, Failures: 0, Errors: 0, Skipped: 0`
- [ ] review
- [ ] more (java)doc
- [ ] more tests
- [ ] publish configuration option to force line separator used in output (AS IS, System.lineSeparator, LF, CR, CRLF)?