### PR TITLE
Fix test failures on Windows

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
@@ -25,6 +25,7 @@ import com.google.common.collect.RangeMap;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeMap;
 import com.google.common.collect.TreeRangeSet;
+import com.google.googlejavaformat.Newlines;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -209,7 +210,7 @@ public class RemoveUnusedImports {
       // delete the import
       int endPosition = importTree.getStartPosition() + importTree.getLength();
       endPosition = Math.max(CharMatcher.isNot(' ').indexIn(contents, endPosition), endPosition);
-      String sep = System.lineSeparator();
+      String sep = Newlines.guessLineSeparator(contents);
       if (endPosition + sep.length() < contents.length()
           && contents.subSequence(endPosition, endPosition + sep.length()).equals(sep)) {
         endPosition += sep.length();

--- a/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
@@ -42,6 +42,9 @@ public class MainTest {
 
   @Rule public TemporaryFolder testFolder = new TemporaryFolder();
 
+  // PrintWriter instances used below are hard-coded to use system-default line separator.
+  private final Joiner joiner = Joiner.on(System.lineSeparator());
+
   @Test
   public void testUsageOutput() {
     StringWriter out = new StringWriter();
@@ -145,11 +148,11 @@ public class MainTest {
       "}",
       "",
     };
-    InputStream in = new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8));
+    InputStream in = new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8));
     StringWriter out = new StringWriter();
     Main main = new Main(new PrintWriter(out, true), new PrintWriter(System.err, true), in);
     assertThat(main.format("-")).isEqualTo(0);
-    assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+    assertThat(out.toString()).isEqualTo(joiner.join(expected));
   }
 
   // end to end import fixing test
@@ -177,11 +180,11 @@ public class MainTest {
         "  public static List<String> names;",
         "}",
       };
-      InputStream in = new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8));
+      InputStream in = new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8));
       StringWriter out = new StringWriter();
       Main main = new Main(new PrintWriter(out, true), new PrintWriter(System.err, true), in);
       assertThat(main.format("-", "--fix-imports-only")).isEqualTo(0);
-      assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+      assertThat(out.toString()).isEqualTo(joiner.join(expected));
     }
     {
       String[] expected = {
@@ -191,13 +194,13 @@ public class MainTest {
         "  public static List<String> names;",
         "}",
       };
-      InputStream in = new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8));
+      InputStream in = new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8));
       StringWriter out = new StringWriter();
       Main main = new Main(new PrintWriter(out, true), new PrintWriter(System.err, true), in);
       assertThat(
               main.format("-", "--fix-imports-only", "--experimental-remove-javadoc-only-imports"))
           .isEqualTo(0);
-      assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+      assertThat(out.toString()).isEqualTo(joiner.join(expected));
     }
   }
 
@@ -224,9 +227,9 @@ public class MainTest {
         new Main(
             new PrintWriter(out, true),
             new PrintWriter(System.err, true),
-            new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8)));
+            new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8)));
     assertThat(main.format("-", "-lines", "4")).isEqualTo(0);
-    assertThat(out.toString()).isEqualTo(Joiner.on('\n').join(expected));
+    assertThat(out.toString()).isEqualTo(joiner.join(expected));
   }
 
   // test that errors are reported on the right line when imports are removed
@@ -244,7 +247,7 @@ public class MainTest {
         new Main(
             new PrintWriter(out, true),
             new PrintWriter(err, true),
-            new ByteArrayInputStream(Joiner.on('\n').join(input).getBytes(UTF_8)));
+            new ByteArrayInputStream(joiner.join(input).getBytes(UTF_8)));
     assertThat(main.format("-")).isEqualTo(1);
     assertThat(err.toString()).contains("<stdin>:4:3: error: class, interface, or enum expected");
   }


### PR DESCRIPTION
Failures in `MainTest` are easy -- [PrintWriter](http://docs.oracle.com/javase/7/docs/api/java/io/PrintWriter.html)s methods use the platform's own notion of line separator rather than the newline character. Just use the system default separator when compiling the expected output.

~~Failures in `RemoveUnusedImportsTest` are **green** on Windows now, but I can't trace an use of `PrintWriter` here. Ah... there's ringing a bell: didn't the `RemoveUnusedImports` somewhere refer to `System.lineSeparator`?~~ BINGO.

Force-pushing the real fix in a minute to this branch.