### PR TITLE
Added format and optimize imports entry point.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -32,6 +32,7 @@ import com.google.googlejavaformat.FormattingError;
 import com.google.googlejavaformat.Newlines;
 import com.google.googlejavaformat.Op;
 import com.google.googlejavaformat.OpsBuilder;
+import com.google.googlejavaformat.java.RemoveUnusedImports.JavadocOnlyImports;
 import com.sun.tools.javac.file.JavacFileManager;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
@@ -194,12 +195,33 @@ public final class Formatter {
   /**
    * Format an input string (a Java compilation unit) into an output string.
    *
+   * <p>Leaves import statements untouched.
+   *
    * @param input the input string
    * @return the output string
    * @throws FormatterException if the input string cannot be parsed
    */
   public String formatSource(String input) throws FormatterException {
     return formatSource(input, Collections.singleton(Range.closedOpen(0, input.length())));
+  }
+
+  /**
+   * Format an input string (a Java compilation unit) and optimize imports into an output string.
+   *
+   * <p>Optimizing imports includes ordering, spacing and removal of unused import statements. An
+   * import used only in a Javadoc comment is considered as unused and therefore removed from the
+   * import statements and its usage within the comment replaced by its fully qualified name.
+   *
+   * @param input the input string
+   * @return the output string
+   * @throws FormatterException if the input string cannot be parsed
+   * @see <a href="https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing">
+   *   Google Java Style Guide - 3.3.3 Import ordering and spacing</a>
+   */
+  public String formatSourceAndOptimizeImports(String input) throws FormatterException {
+    input = ImportOrderer.reorderImports(input);
+    input = RemoveUnusedImports.removeUnusedImports(input, JavadocOnlyImports.REMOVE);
+    return formatSource(input);
   }
 
   /**

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
@@ -249,6 +249,15 @@ public final class FormatterTest {
   }
 
   @Test
+  public void importsOptimizedIfRequested() throws FormatterException {
+    String input =
+      "package com.google.example;\n" + UNORDERED_IMPORTS + "\npublic class ExampleTest {}\n";
+    String output = new Formatter().formatSourceAndOptimizeImports(input);
+    String expect = "package com.google.example;\n\npublic class ExampleTest {}\n";
+    assertThat(output).isEqualTo(expect);
+  }
+
+  @Test
   public void importOrderingWithoutFormatting() throws IOException, UsageException {
     importOrdering(
         "--fix-imports-only", "com/google/googlejavaformat/java/testimports/A.imports-only");


### PR DESCRIPTION
This PR introduces a new entry point in `Formatter`, that format an input string (a Java compilation unit) and optimize imports into an output string.

The new entry point `formatSource(String, JavadocOnlyImports )` behaves similar to the `Main`/`FormatFileCallable` combo, that allows optimizing imports in Java source files. It provides a better manner for external application to invoke the expected behaviour of google-java-format programmatically -- without utilizing the `Main`/`FormatFileCallable` combo path discussed here https://github.com/diffplug/spotless/issues/48