### PR TITLE
Annotated varargs test and crash fix.

### DIFF
--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/Varargs.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/Varargs.input
@@ -1,0 +1,8 @@
+import org.checkerframework.checker.nullness.qual.*;
+
+public class Varargs {
+
+    public void format2(Object @Nullable ... a2) {
+    }
+
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/Varargs.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/Varargs.output
@@ -1,0 +1,6 @@
+import org.checkerframework.checker.nullness.qual.*;
+
+public class Varargs {
+
+  public void format2(Object @Nullable... a2) {}
+}


### PR DESCRIPTION
Fixes #95 -- actually fixes the symptom, passes the test, but needs some work to convert the actual list of annotation instances to tree elements.