### PR TITLE
Add --skip-sorting-imports flag to skip sorting imports.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
@@ -36,6 +36,7 @@ final class CommandLineOptions {
   private final boolean stdin;
   private final boolean fixImportsOnly;
   private final boolean removeJavadocOnlyImports;
+  private final boolean sortImports;
 
   CommandLineOptions(
       ImmutableList<String> files,
@@ -48,7 +49,8 @@ final class CommandLineOptions {
       boolean help,
       boolean stdin,
       boolean fixImportsOnly,
-      boolean removeJavadocOnlyImports) {
+      boolean removeJavadocOnlyImports,
+      boolean sortImports) {
     this.files = files;
     this.inPlace = inPlace;
     this.lines = lines;
@@ -60,6 +62,7 @@ final class CommandLineOptions {
     this.stdin = stdin;
     this.fixImportsOnly = fixImportsOnly;
     this.removeJavadocOnlyImports = removeJavadocOnlyImports;
+    this.sortImports = sortImports;
   }
 
   /** The files to format. */
@@ -120,6 +123,11 @@ final class CommandLineOptions {
     return removeJavadocOnlyImports;
   }
 
+  /** Sort imports. */
+  boolean sortImports() {
+    return sortImports;
+  }
+
   /** Returns true if partial formatting was selected. */
   boolean isSelection() {
     return !lines().isEmpty() || !offsets().isEmpty() || !lengths().isEmpty();
@@ -142,6 +150,7 @@ final class CommandLineOptions {
     private Boolean stdin = false;
     private Boolean fixImportsOnly = false;
     private Boolean removeJavadocOnlyImports = false;
+    private Boolean sortImports = true;
 
     ImmutableList.Builder<String> filesBuilder() {
       return files;
@@ -196,6 +205,11 @@ final class CommandLineOptions {
       return this;
     }
 
+    Builder sortImports(boolean sortImports) {
+      this.sortImports = sortImports;
+      return this;
+    }
+
     CommandLineOptions build() {
       return new CommandLineOptions(
           this.files.build(),
@@ -208,7 +222,8 @@ final class CommandLineOptions {
           this.help,
           this.stdin,
           this.fixImportsOnly,
-          this.removeJavadocOnlyImports);
+          this.removeJavadocOnlyImports,
+          this.sortImports);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
@@ -89,6 +89,9 @@ final class CommandLineOptionsParser {
         case "--experimental-remove-javadoc-only-imports":
           optionsBuilder.removeJavadocOnlyImports(true);
           break;
+        case "--skip-sorting-imports":
+          optionsBuilder.sortImports(false);
+          break;
         case "-":
           optionsBuilder.stdin(true);
           break;

--- a/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
@@ -55,7 +55,9 @@ public class FormatFileCallable implements Callable<String> {
             parameters.removeJavadocOnlyImports()
                 ? JavadocOnlyImports.REMOVE
                 : JavadocOnlyImports.KEEP);
-    input = ImportOrderer.reorderImports(input);
+    if (parameters.sortImports()) {
+      input = ImportOrderer.reorderImports(input);
+    }
     return input;
   }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
@@ -40,6 +40,8 @@ public final class UsageException extends Exception {
     "    Use AOSP style instead of Google Style (4-space indentation)",
     "  --fix-imports-only",
     "    Fix import order and remove any unused imports, but do no other formatting.",
+    "  --skip-sorting-imports",
+    "    Do not fix the import order. Unused imports will still be removed.",
     "  --length, -length",
     "    Character length to format.",
     "  --lines, -lines, --line, -line",

--- a/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
@@ -40,6 +40,7 @@ public class CommandLineOptionsParserTest {
     assertThat(options.offsets()).isEmpty();
     assertThat(options.inPlace()).isFalse();
     assertThat(options.version()).isFalse();
+    assertThat(options.sortImports()).isTrue();
   }
 
   @Test
@@ -106,6 +107,14 @@ public class CommandLineOptionsParserTest {
   @Test
   public void version() {
     assertThat(CommandLineOptionsParser.parse(Arrays.asList("-v")).version()).isTrue();
+  }
+
+  @Test
+  public void skipSortingImports() {
+    assertThat(
+            CommandLineOptionsParser.parse(Arrays.asList("--skip-sorting-imports"))
+                .sortImports())
+        .isFalse();
   }
 
   // TODO(cushon): consider handling this in the parser and reporting a more detailed error

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
@@ -259,6 +259,13 @@ public final class FormatterTest {
     importOrdering(null, "com/google/googlejavaformat/java/testimports/A.imports-and-formatting");
   }
 
+  @Test
+  public void formattingWithoutImportOrdering() throws IOException, UsageException {
+    importOrdering(
+        "--skip-sorting-imports",
+        "com/google/googlejavaformat/java/testimports/A.formatting-only");
+  }
+
   private void importOrdering(String sortArg, String outputResourceName)
       throws IOException, UsageException {
     Path tmpdir = testFolder.newFolder().toPath();

--- a/core/src/test/resources/com/google/googlejavaformat/java/testimports/A.formatting-only
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testimports/A.formatting-only
@@ -6,14 +6,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.util.List;
-import java.util.Set;
 
 import javax.annotations.Nullable;
 
 import static org.junit.Assert.fail;
 import static com.google.truth.Truth.assertThat;
 
-@RunWith( JUnit4.class ) public class SomeTest  {
+@RunWith(JUnit4.class)
+public class SomeTest {
 
   <T> void check(@Nullable List<T> x) {
     Preconditions.checkNodeNull(x);


### PR DESCRIPTION
Unused imports will still be removed.