### PR TITLE
Prevent edit if nothing was formatted

### DIFF
--- a/eclipse_plugin/src/com/google/googlejavaformat/java/GoogleJavaFormatter.java
+++ b/eclipse_plugin/src/com/google/googlejavaformat/java/GoogleJavaFormatter.java
@@ -86,22 +86,24 @@ public class GoogleJavaFormatter extends CodeFormatter {
           new SnippetFormatter()
               .format(
                   snippetKind, source, rangesFromRegions(regions), initialIndent, includeComments);
-      // Trivial case: no replacement, no change.
+      // Trivial case: no replacement, nothing changed.
       if (replacements.isEmpty()) {
         return null;
       }
-      // Entire source case: input = output, no change.
-      if (replacements.size() == 1 && replacements.get(0).getReplacementString().equals(source)) {
-        return null;
-      }
-      // Single region and replacement case: if they are equals, no change.
-      if (replacements.size() == 1 && regions.length == 1) {
-        Replacement replacement = replacements.get(0);
-        String output = replacement.getReplacementString();
-        Range<Integer> replaceRange = replacement.getReplaceRange();
-        String input = source.substring(replaceRange.lowerEndpoint(), replaceRange.upperEndpoint());
-        if (output.equals(input)) {
+      if (replacements.size() == 1) {
+        // Entire source case: input = output, nothing changed.
+        if (replacements.get(0).getReplacementString().equals(source)) {
           return null;
+        }
+        // Single region and single replacement case: if they are equal, nothing changed.
+        if (regions.length == 1) {
+          Replacement replacement = replacements.get(0);
+          String output = replacement.getReplacementString();
+          Range<Integer> range = replacement.getReplaceRange();
+          String input = source.substring(range.lowerEndpoint(), range.upperEndpoint());
+          if (output.equals(input)) {
+            return null;
+          }
         }
       }
       // Convert replacements to text edits.

--- a/eclipse_plugin/src/com/google/googlejavaformat/java/GoogleJavaFormatter.java
+++ b/eclipse_plugin/src/com/google/googlejavaformat/java/GoogleJavaFormatter.java
@@ -86,25 +86,9 @@ public class GoogleJavaFormatter extends CodeFormatter {
           new SnippetFormatter()
               .format(
                   snippetKind, source, rangesFromRegions(regions), initialIndent, includeComments);
-      // Trivial case: no replacement, nothing changed.
-      if (replacements.isEmpty()) {
+      if (idempotent(source, regions, replacements)) {
+        // Do not create edits if there's no diff.
         return null;
-      }
-      if (replacements.size() == 1) {
-        // Entire source case: input = output, nothing changed.
-        if (replacements.get(0).getReplacementString().equals(source)) {
-          return null;
-        }
-        // Single region and single replacement case: if they are equal, nothing changed.
-        if (regions.length == 1) {
-          Replacement replacement = replacements.get(0);
-          String output = replacement.getReplacementString();
-          Range<Integer> range = replacement.getReplaceRange();
-          String input = source.substring(range.lowerEndpoint(), range.upperEndpoint());
-          if (output.equals(input)) {
-            return null;
-          }
-        }
       }
       // Convert replacements to text edits.
       return editFromReplacements(replacements);
@@ -120,6 +104,28 @@ public class GoogleJavaFormatter extends CodeFormatter {
       ranges.add(Range.closedOpen(region.getOffset(), region.getOffset() + region.getLength()));
     }
     return ranges;
+  }
+
+  /** @return {@code true} if input and output texts are equal, else {@code false}. */
+  private boolean idempotent(String source, IRegion[] regions, List<Replacement> replacements) {
+    // This implementation only checks for single replacement.
+    if (replacements.size() == 1) {
+      Replacement replacement = replacements.get(0);
+      String output = replacement.getReplacementString();
+      // Entire source case: input = output, nothing changed.
+      if (output.equals(source)) {
+        return true;
+      }
+      // Single region and single replacement case: if they are equal, nothing changed.
+      if (regions.length == 1) {
+        Range<Integer> range = replacement.getReplaceRange();
+        String snippet = source.substring(range.lowerEndpoint(), range.upperEndpoint());
+        if (output.equals(snippet)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private TextEdit editFromReplacements(List<Replacement> replacements) {


### PR DESCRIPTION
Handle trivial cases, where input equals output, to prevent dirty flags in active editors.