### PR TITLE
Swap out JDK singleton list usages with ImmutableList

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticCollector;
@@ -199,7 +198,7 @@ public final class Formatter {
    * @throws FormatterException if the input string cannot be parsed
    */
   public String formatSource(String input) throws FormatterException {
-    return formatSource(input, Collections.singleton(Range.closedOpen(0, input.length())));
+    return formatSource(input, ImmutableList.of(Range.closedOpen(0, input.length())));
   }
 
   /**

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -68,7 +68,6 @@ import com.google.googlejavaformat.java.DimensionHelpers.SortedDims;
 import com.google.googlejavaformat.java.DimensionHelpers.TypeWithDims;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
@@ -296,7 +295,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
   }
 
   /** A record of whether we have visited into an expression. */
-  private final Deque<Boolean> inExpression = new ArrayDeque<>(Arrays.asList(false));
+  private final Deque<Boolean> inExpression = new ArrayDeque<>(ImmutableList.of(false));
 
   private boolean inExpression() {
     return inExpression.peekLast();

--- a/core/src/main/java/com/google/googlejavaformat/java/ModifierOrderer.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/ModifierOrderer.java
@@ -77,7 +77,7 @@ final class ModifierOrderer {
   /** Reorders all modifiers in the given text to be in JLS order. */
   static JavaInput reorderModifiers(String text) throws FormatterException {
     return reorderModifiers(
-        new JavaInput(text), Collections.singleton(Range.closedOpen(0, text.length())));
+        new JavaInput(text), ImmutableList.of(Range.closedOpen(0, text.length())));
   }
 
   /**


### PR DESCRIPTION
This helps to make the code a little more consistent and maintainable, since all singleton lists now use the same class.