### PR TITLE
Expand IntelliJ section in README to suggest formatter style.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ files. Until IntelliJ is restarted, the `Reformat code` action will also
 There is an [open bug](https://devnet.jetbrains.com/thread/464297) against
 IntelliJ to add support for configuring external formatters.
 
+If this is currently not an option for your team, you could also use the
+formatter 
+[rule set](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
+for intellij as a work-around.
+
+
 ### Eclipse
 
 A [google-java-format Eclipse

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -29,7 +29,7 @@ import com.google.errorprone.annotations.Immutable;
 @Immutable
 public class JavaFormatterOptions {
 
-  static final int DEFAULT_MAX_LINE_LENGTH = 100;
+  static final int DEFAULT_MAX_LINE_LENGTH = 150;
 
   public enum Style {
 


### PR DESCRIPTION
Because it is not really practical to tell our team members to manually format with the google-java-formatter one time after every start-up, I looked for a different solution and finally found the intellij style.xml.

This pull-request is for expanding the README to suggest this for others who are also faced with the same situation.