### PR TITLE
Add flag for skipping javadoc formatting

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
@@ -38,7 +38,7 @@ final class CommandLineOptions {
   private final boolean removeJavadocOnlyImports;
   private final boolean sortImports;
   private final boolean removeUnusedImports;
-  private final boolean skipJavaDocFormatting;
+  private final boolean skipJavadocFormatting;
 
   CommandLineOptions(
       ImmutableList<String> files,
@@ -54,7 +54,7 @@ final class CommandLineOptions {
       boolean removeJavadocOnlyImports,
       boolean sortImports,
       boolean removeUnusedImports,
-      boolean skipJavaDocFormatting) {
+      boolean skipJavadocFormatting) {
     this.files = files;
     this.inPlace = inPlace;
     this.lines = lines;
@@ -68,7 +68,7 @@ final class CommandLineOptions {
     this.removeJavadocOnlyImports = removeJavadocOnlyImports;
     this.sortImports = sortImports;
     this.removeUnusedImports = removeUnusedImports;
-    this.skipJavaDocFormatting = skipJavaDocFormatting;
+    this.skipJavadocFormatting = skipJavadocFormatting;
   }
 
   /** The files to format. */
@@ -139,8 +139,8 @@ final class CommandLineOptions {
     return removeUnusedImports;
   }
 
-  boolean skipJavaDocFormatting() {
-    return skipJavaDocFormatting;
+  boolean skipJavadocFormatting() {
+    return skipJavadocFormatting;
   }
 
   /** Returns true if partial formatting was selected. */
@@ -167,7 +167,7 @@ final class CommandLineOptions {
     private Boolean removeJavadocOnlyImports = false;
     private Boolean sortImports = true;
     private Boolean removeUnusedImports = true;
-    private Boolean skipJavaDocFormatting = false;
+    private Boolean skipJavadocFormatting = false;
 
     ImmutableList.Builder<String> filesBuilder() {
       return files;
@@ -232,8 +232,8 @@ final class CommandLineOptions {
       return this;
     }
 
-    Builder skipJavaDocFormatting(boolean skipJavaDocFormatting) {
-      this.skipJavaDocFormatting = skipJavaDocFormatting;
+    Builder skipJavadocFormatting(boolean skipJavadocFormatting) {
+      this.skipJavadocFormatting = skipJavadocFormatting;
       return this;
     }
 
@@ -252,7 +252,7 @@ final class CommandLineOptions {
           this.removeJavadocOnlyImports,
           this.sortImports,
           this.removeUnusedImports,
-          this.skipJavaDocFormatting);
+          this.skipJavadocFormatting);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
@@ -38,6 +38,7 @@ final class CommandLineOptions {
   private final boolean removeJavadocOnlyImports;
   private final boolean sortImports;
   private final boolean removeUnusedImports;
+  private final boolean skipJavaDocFormatting;
 
   CommandLineOptions(
       ImmutableList<String> files,
@@ -52,7 +53,8 @@ final class CommandLineOptions {
       boolean fixImportsOnly,
       boolean removeJavadocOnlyImports,
       boolean sortImports,
-      boolean removeUnusedImports) {
+      boolean removeUnusedImports,
+      boolean skipJavaDocFormatting) {
     this.files = files;
     this.inPlace = inPlace;
     this.lines = lines;
@@ -66,6 +68,7 @@ final class CommandLineOptions {
     this.removeJavadocOnlyImports = removeJavadocOnlyImports;
     this.sortImports = sortImports;
     this.removeUnusedImports = removeUnusedImports;
+    this.skipJavaDocFormatting = skipJavaDocFormatting;
   }
 
   /** The files to format. */
@@ -136,6 +139,10 @@ final class CommandLineOptions {
     return removeUnusedImports;
   }
 
+  boolean skipJavaDocFormatting() {
+    return skipJavaDocFormatting;
+  }
+
   /** Returns true if partial formatting was selected. */
   boolean isSelection() {
     return !lines().isEmpty() || !offsets().isEmpty() || !lengths().isEmpty();
@@ -160,6 +167,7 @@ final class CommandLineOptions {
     private Boolean removeJavadocOnlyImports = false;
     private Boolean sortImports = true;
     private Boolean removeUnusedImports = true;
+    private Boolean skipJavaDocFormatting = false;
 
     ImmutableList.Builder<String> filesBuilder() {
       return files;
@@ -224,6 +232,11 @@ final class CommandLineOptions {
       return this;
     }
 
+    Builder skipJavaDocFormatting(boolean skipJavaDocFormatting) {
+      this.skipJavaDocFormatting = skipJavaDocFormatting;
+      return this;
+    }
+
     CommandLineOptions build() {
       return new CommandLineOptions(
           this.files.build(),
@@ -238,7 +251,8 @@ final class CommandLineOptions {
           this.fixImportsOnly,
           this.removeJavadocOnlyImports,
           this.sortImports,
-          this.removeUnusedImports);
+          this.removeUnusedImports,
+          this.skipJavaDocFormatting);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
@@ -96,7 +96,7 @@ final class CommandLineOptionsParser {
           optionsBuilder.removeUnusedImports(false);
           break;
         case "--skip-javadoc-formatting":
-          optionsBuilder.skipJavaDocFormatting(true);
+          optionsBuilder.skipJavadocFormatting(true);
           break;
         case "-":
           optionsBuilder.stdin(true);

--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
@@ -95,6 +95,9 @@ final class CommandLineOptionsParser {
         case "--skip-removing-unused-imports":
           optionsBuilder.removeUnusedImports(false);
           break;
+        case "--skip-javadoc-formatting":
+          optionsBuilder.skipJavaDocFormatting(true);
+          break;
         case "-":
           optionsBuilder.stdin(true);
           break;

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -41,7 +41,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
       return tok.getOriginalText();
     }
     String text = tok.getOriginalText();
-    if (tok.isJavadocComment() && !options.skipJavaDocFormatting()) {
+    if (tok.isJavadocComment() && !options.skipJavadocFormatting()) {
       text = JavadocFormatter.formatJavadoc(text, column0, options);
     }
     List<String> lines = new ArrayList<>();
@@ -162,4 +162,3 @@ public final class JavaCommentsHelper implements CommentsHelper {
     return true;
   }
 }
-

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -41,7 +41,7 @@ public final class JavaCommentsHelper implements CommentsHelper {
       return tok.getOriginalText();
     }
     String text = tok.getOriginalText();
-    if (tok.isJavadocComment()) {
+    if (tok.isJavadocComment() && !options.skipJavaDocFormatting()) {
       text = JavadocFormatter.formatJavadoc(text, column0, options);
     }
     List<String> lines = new ArrayList<>();

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -51,9 +51,11 @@ public class JavaFormatterOptions {
   }
 
   private final Style style;
+  private final boolean skipJavaDocFormatting;
 
-  private JavaFormatterOptions(Style style) {
+  private JavaFormatterOptions(Style style, boolean skipJavaDocFormatting) {
     this.style = style;
+    this.skipJavaDocFormatting = skipJavaDocFormatting;
   }
 
   /** Returns the maximum formatted width */
@@ -64,6 +66,11 @@ public class JavaFormatterOptions {
   /** Returns the multiplier for the unit of indent */
   public int indentationMultiplier() {
     return style.indentationMultiplier();
+  }
+
+  /** Returns if javadoc formatting should be skipped. */
+  public boolean skipJavaDocFormatting() {
+    return skipJavaDocFormatting;
   }
 
   /** Returns the default formatting options. */
@@ -79,6 +86,7 @@ public class JavaFormatterOptions {
   /** A builder for {@link JavaFormatterOptions}. */
   public static class Builder {
     private Style style = Style.GOOGLE;
+    private boolean skipJavaDocFormatting = false;
 
     private Builder() {}
 
@@ -87,8 +95,13 @@ public class JavaFormatterOptions {
       return this;
     }
 
+    public Builder skipJavaDocFormatting(boolean skipJavaDocFormatting) {
+      this.skipJavaDocFormatting = skipJavaDocFormatting;
+      return this;
+    }
+
     public JavaFormatterOptions build() {
-      return new JavaFormatterOptions(style);
+      return new JavaFormatterOptions(style, skipJavaDocFormatting);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -51,11 +51,11 @@ public class JavaFormatterOptions {
   }
 
   private final Style style;
-  private final boolean skipJavaDocFormatting;
+  private final boolean skipJavadocFormatting;
 
-  private JavaFormatterOptions(Style style, boolean skipJavaDocFormatting) {
+  private JavaFormatterOptions(Style style, boolean skipJavadocFormatting) {
     this.style = style;
-    this.skipJavaDocFormatting = skipJavaDocFormatting;
+    this.skipJavadocFormatting = skipJavadocFormatting;
   }
 
   /** Returns the maximum formatted width */
@@ -69,8 +69,8 @@ public class JavaFormatterOptions {
   }
 
   /** Returns if javadoc formatting should be skipped. */
-  public boolean skipJavaDocFormatting() {
-    return skipJavaDocFormatting;
+  public boolean skipJavadocFormatting() {
+    return skipJavadocFormatting;
   }
 
   /** Returns the default formatting options. */
@@ -86,7 +86,7 @@ public class JavaFormatterOptions {
   /** A builder for {@link JavaFormatterOptions}. */
   public static class Builder {
     private Style style = Style.GOOGLE;
-    private boolean skipJavaDocFormatting = false;
+    private boolean skipJavadocFormatting = false;
 
     private Builder() {}
 
@@ -95,13 +95,13 @@ public class JavaFormatterOptions {
       return this;
     }
 
-    public Builder skipJavaDocFormatting(boolean skipJavaDocFormatting) {
-      this.skipJavaDocFormatting = skipJavaDocFormatting;
+    public Builder skipJavadocFormatting(boolean skipJavadocFormatting) {
+      this.skipJavadocFormatting = skipJavadocFormatting;
       return this;
     }
 
     public JavaFormatterOptions build() {
-      return new JavaFormatterOptions(style, skipJavaDocFormatting);
+      return new JavaFormatterOptions(style, skipJavadocFormatting);
     }
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -99,9 +99,9 @@ public final class Main {
 
     JavaFormatterOptions options =
         JavaFormatterOptions.builder()
-                .style(parameters.aosp() ? Style.AOSP : Style.GOOGLE)
-                .skipJavaDocFormatting(parameters.skipJavaDocFormatting())
-                .build();
+            .style(parameters.aosp() ? Style.AOSP : Style.GOOGLE)
+            .skipJavadocFormatting(parameters.skipJavadocFormatting())
+            .build();
 
     if (parameters.stdin()) {
       return formatStdin(parameters, options);

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -98,7 +98,10 @@ public final class Main {
     }
 
     JavaFormatterOptions options =
-        JavaFormatterOptions.builder().style(parameters.aosp() ? Style.AOSP : Style.GOOGLE).build();
+        JavaFormatterOptions.builder()
+                .style(parameters.aosp() ? Style.AOSP : Style.GOOGLE)
+                .skipJavaDocFormatting(parameters.skipJavaDocFormatting())
+                .build();
 
     if (parameters.stdin()) {
       return formatStdin(parameters, options);

--- a/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
@@ -44,6 +44,8 @@ public final class UsageException extends Exception {
     "    Do not fix the import order. Unused imports will still be removed.",
     "  --skip-removing-unused-imports",
     "    Do not remove unused imports. Imports will still be sorted.",
+    "  --skip-javadoc-formatting",
+    "    Do not format javadoc comments. Comments will still be trimmed, indented and fixed for missing asterisks.",
     "  --length, -length",
     "    Character length to format.",
     "  --lines, -lines, --line, -line",

--- a/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
@@ -14,16 +14,15 @@
 
 package com.google.googlejavaformat.java;
 
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.base.Joiner;
 import com.google.common.io.ByteStreams;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.Arrays;
-
-import static com.google.common.truth.Truth.assertThat;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Tests formatting javadoc. */
 @RunWith(JUnit4.class)
@@ -1341,25 +1340,25 @@ public final class JavadocFormattingTest {
   public void skipEmpty() {
     // For skip javadoc formatting cases all we care about are that the comments are unchanged.
     String[] input = {
-            "/***/", //
-            "class Test {}",
+      "/***/", //
+      "class Test {}",
     };
     doSkipFormatTest(input, input);
   }
 
   @Test
-  public void skipNoAsterisk() {
+  public void skipJavadocFormattingStillFixesNoAsterisk() {
     String[] input = {
-            "/**", //
-            " abc<p>def",
-            " */",
-            "class Test {}",
+      "/**", //
+      " abc<p>def",
+      " */",
+      "class Test {}",
     };
     String[] expected = {
-            "/**", //
-            " * abc<p>def",
-            " */",
-            "class Test {}",
+      "/**", //
+      " * abc<p>def",
+      " */",
+      "class Test {}",
     };
     doSkipFormatTest(input, expected);
   }
@@ -1368,32 +1367,32 @@ public final class JavadocFormattingTest {
   public void skipListHtmlButFixIndentation() {
     // Skipping javadoc formatting doesn't stop fixing indentation.
     String[] input = {
-            "/**", //
-            "* hi",
-            "*",
-            "* <ul>",
-            "* <li>",
-            "* <ul>",
-            "* <li>a</li>",
-            "* </ul>",
-            "* </li>",
-            "* </ul>",
-            "*/",
-            "class Test {}",
+      "/**", //
+      "* hi",
+      "*",
+      "* <ul>",
+      "* <li>",
+      "* <ul>",
+      "* <li>a</li>",
+      "* </ul>",
+      "* </li>",
+      "* </ul>",
+      "*/",
+      "class Test {}",
     };
     String[] expected = {
-            "/**", //
-            " * hi",
-            " *",
-            " * <ul>",
-            " * <li>",
-            " * <ul>",
-            " * <li>a</li>",
-            " * </ul>",
-            " * </li>",
-            " * </ul>",
-            " */",
-            "class Test {}",
+      "/**", //
+      " * hi",
+      " *",
+      " * <ul>",
+      " * <li>",
+      " * <ul>",
+      " * <li>a</li>",
+      " * </ul>",
+      " * </li>",
+      " * </ul>",
+      " */",
+      "class Test {}",
     };
     doSkipFormatTest(input, expected);
   }
@@ -1401,32 +1400,32 @@ public final class JavadocFormattingTest {
   @Test
   public void skipInferParagraphTags() {
     String[] input = {
-            "/**",
-            " *",
-            " *",
-            " * foo",
-            " * foo",
-            " *",
-            " *",
-            " * foo",
-            " *",
-            " * bar",
-            " *",
-            " * <pre>",
-            " *",
-            " * baz",
-            " *",
-            " * </pre>",
-            " *",
-            " * <ul>",
-            " * <li>foo",
-            " *",
-            " * bar",
-            " * </ul>",
-            " *",
-            " *",
-            " */",
-            "class Test {}",
+      "/**",
+      " *",
+      " *",
+      " * foo",
+      " * foo",
+      " *",
+      " *",
+      " * foo",
+      " *",
+      " * bar",
+      " *",
+      " * <pre>",
+      " *",
+      " * baz",
+      " *",
+      " * </pre>",
+      " *",
+      " * <ul>",
+      " * <li>foo",
+      " *",
+      " * bar",
+      " * </ul>",
+      " *",
+      " *",
+      " */",
+      "class Test {}",
     };
     doSkipFormatTest(input, input);
   }
@@ -1434,12 +1433,12 @@ public final class JavadocFormattingTest {
   @Test
   public void skipRemoveCloseTags() {
     String[] input = {
-            "/**", //
-            " * foo</p>",
-            " *",
-            " * <p>bar</p>",
-            " */",
-            "class Test {}",
+      "/**", //
+      " * foo</p>",
+      " *",
+      " * <p>bar</p>",
+      " */",
+      "class Test {}",
     };
     doSkipFormatTest(input, input);
   }
@@ -1455,7 +1454,8 @@ public final class JavadocFormattingTest {
 
   private void doSkipFormatTest(String[] input, String[] expected) {
     try {
-      Formatter skipFormatter = new Formatter(JavaFormatterOptions.builder().skipJavaDocFormatting(true).build());
+      Formatter skipFormatter =
+          new Formatter(JavaFormatterOptions.builder().skipJavadocFormatting(true).build());
       String actual = skipFormatter.formatSource(Joiner.on('\n').join(input));
       assertThat(actual).isEqualTo(Joiner.on('\n').join(expected) + "\n");
     } catch (FormatterException e) {

--- a/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/JavadocFormattingTest.java
@@ -14,15 +14,16 @@
 
 package com.google.googlejavaformat.java;
 
-import static com.google.common.truth.Truth.assertThat;
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.common.base.Joiner;
 import com.google.common.io.ByteStreams;
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Tests formatting javadoc. */
 @RunWith(JUnit4.class)
@@ -1336,9 +1337,126 @@ public final class JavadocFormattingTest {
     doFormatTest(input, expected);
   }
 
+  @Test
+  public void skipEmpty() {
+    // For skip javadoc formatting cases all we care about are that the comments are unchanged.
+    String[] input = {
+            "/***/", //
+            "class Test {}",
+    };
+    doSkipFormatTest(input, input);
+  }
+
+  @Test
+  public void skipNoAsterisk() {
+    String[] input = {
+            "/**", //
+            " abc<p>def",
+            " */",
+            "class Test {}",
+    };
+    String[] expected = {
+            "/**", //
+            " * abc<p>def",
+            " */",
+            "class Test {}",
+    };
+    doSkipFormatTest(input, expected);
+  }
+
+  @Test
+  public void skipListHtmlButFixIndentation() {
+    // Skipping javadoc formatting doesn't stop fixing indentation.
+    String[] input = {
+            "/**", //
+            "* hi",
+            "*",
+            "* <ul>",
+            "* <li>",
+            "* <ul>",
+            "* <li>a</li>",
+            "* </ul>",
+            "* </li>",
+            "* </ul>",
+            "*/",
+            "class Test {}",
+    };
+    String[] expected = {
+            "/**", //
+            " * hi",
+            " *",
+            " * <ul>",
+            " * <li>",
+            " * <ul>",
+            " * <li>a</li>",
+            " * </ul>",
+            " * </li>",
+            " * </ul>",
+            " */",
+            "class Test {}",
+    };
+    doSkipFormatTest(input, expected);
+  }
+
+  @Test
+  public void skipInferParagraphTags() {
+    String[] input = {
+            "/**",
+            " *",
+            " *",
+            " * foo",
+            " * foo",
+            " *",
+            " *",
+            " * foo",
+            " *",
+            " * bar",
+            " *",
+            " * <pre>",
+            " *",
+            " * baz",
+            " *",
+            " * </pre>",
+            " *",
+            " * <ul>",
+            " * <li>foo",
+            " *",
+            " * bar",
+            " * </ul>",
+            " *",
+            " *",
+            " */",
+            "class Test {}",
+    };
+    doSkipFormatTest(input, input);
+  }
+
+  @Test
+  public void skipRemoveCloseTags() {
+    String[] input = {
+            "/**", //
+            " * foo</p>",
+            " *",
+            " * <p>bar</p>",
+            " */",
+            "class Test {}",
+    };
+    doSkipFormatTest(input, input);
+  }
+
   private void doFormatTest(String[] input, String[] expected) {
     try {
       String actual = formatter.formatSource(Joiner.on('\n').join(input));
+      assertThat(actual).isEqualTo(Joiner.on('\n').join(expected) + "\n");
+    } catch (FormatterException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private void doSkipFormatTest(String[] input, String[] expected) {
+    try {
+      Formatter skipFormatter = new Formatter(JavaFormatterOptions.builder().skipJavaDocFormatting(true).build());
+      String actual = skipFormatter.formatSource(Joiner.on('\n').join(input));
       assertThat(actual).isEqualTo(Joiner.on('\n').join(expected) + "\n");
     } catch (FormatterException e) {
       throw new AssertionError(e);


### PR DESCRIPTION
Adds the command line flag `--skip-javadoc-formatting` to enable
skipping javadoc formatting. Only the HTML formatting of javadoc is
skipped, not things like fixing indentation, missing asterisks and
trimming. This commit does not attempt to solve issues that arise when
using other formatting standards, simply just to preserve the text
inside of the javadoc. For examples, see the tests added to
JavadocFormattingTest.

Issue: https://github.com/google/google-java-format/issues/139