### PR TITLE
Upgrade to JUnit 5 and Surefire 2.19.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -59,6 +59,12 @@
 
     <!-- Test dependencies -->
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.0.0-RC2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/core/src/test/java/com/google/googlejavaformat/NewlinesTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/NewlinesTest.java
@@ -20,15 +20,12 @@ import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /** {@link Newlines}Test */
-@RunWith(JUnit4.class)
-public class NewlinesTest {
+class NewlinesTest {
   @Test
-  public void offsets() {
+  void offsets() {
     assertThat(ImmutableList.copyOf(Newlines.lineOffsetIterator("foo\nbar\n")))
         .containsExactly(0, 4, 8);
     assertThat(ImmutableList.copyOf(Newlines.lineOffsetIterator("foo\nbar"))).containsExactly(0, 4);
@@ -44,7 +41,7 @@ public class NewlinesTest {
   }
 
   @Test
-  public void lines() {
+  void lines() {
     assertThat(ImmutableList.copyOf(Newlines.lineIterator("foo\nbar\n")))
         .containsExactly("foo\n", "bar\n");
     assertThat(ImmutableList.copyOf(Newlines.lineIterator("foo\nbar")))
@@ -62,7 +59,7 @@ public class NewlinesTest {
   }
 
   @Test
-  public void terminalOffset() {
+  void terminalOffset() {
     Iterator<Integer> it = Newlines.lineOffsetIterator("foo\nbar\n");
     it.next();
     it.next();
@@ -86,7 +83,7 @@ public class NewlinesTest {
   }
 
   @Test
-  public void terminalLine() {
+  void terminalLine() {
     Iterator<String> it = Newlines.lineIterator("foo\nbar\n");
     it.next();
     it.next();

--- a/pom.xml
+++ b/pom.xml
@@ -243,11 +243,28 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18</version>
+        <version>2.19.1</version>
         <configuration>
           <!-- set heap size to work around http://github.com/travis-ci/travis-ci/issues/3396 -->
           <argLine>-Xmx1024m</argLine>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+            <version>1.0.0-RC2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.0.0-RC2</version>
+          </dependency>
+          <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>4.12.0-RC2</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
This PR introduces **JUnit 5** as a dependency and ports a single test class, namely `NewlinesTest.java`, to the new [JUnit Jupiter API](http://junit.org/junit5/docs/current/user-guide/).

### Todo
- [ ] Convert all remaining test classes to JUnit 5