### PR TITLE
Set supported Java source level to "9"

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -47,6 +47,7 @@ import org.openjdk.javax.tools.JavaFileObject;
 import org.openjdk.javax.tools.SimpleJavaFileObject;
 import org.openjdk.javax.tools.StandardLocation;
 import org.openjdk.tools.javac.file.JavacFileManager;
+import org.openjdk.tools.javac.main.Option;
 import org.openjdk.tools.javac.parser.JavacParser;
 import org.openjdk.tools.javac.parser.ParserFactory;
 import org.openjdk.tools.javac.tree.JCTree.JCCompilationUnit;
@@ -135,6 +136,10 @@ public final class Formatter {
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     context.put(DiagnosticListener.class, diagnostics);
     Options.instance(context).put("allowStringFolding", "false");
+    // TODO(cushon): this should default to the latest supported source level, remove this after
+    // backing out
+    // https://github.com/google/error-prone-javac/commit/c97f34ddd2308302587ce2de6d0c984836ea5b9f
+    Options.instance(context).put(Option.SOURCE, "9");
     JCCompilationUnit unit;
     JavacFileManager fileManager = new JavacFileManager(context, true, UTF_8);
     try {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/i176.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/i176.input
@@ -1,0 +1,6 @@
+interface
+InterfaceWithPrivateStaticMethod
+{
+  private static void bar() { }
+  default void foo() { bar(); }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/i176.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/i176.output
@@ -1,0 +1,7 @@
+interface InterfaceWithPrivateStaticMethod {
+  private static void bar() {}
+
+  default void foo() {
+    bar();
+  }
+}


### PR DESCRIPTION
Fixes #176 by setting the default javac source level to "9".

This PR superseds #177 as it includes the failing and ignored as well.
