### PR TITLE
idea_plugin README: Add macOS menu location to instructions

### DIFF
--- a/idea_plugin/README.md
+++ b/idea_plugin/README.md
@@ -3,8 +3,9 @@
 ## Enabling
 
 The plugin will not be enabled by default. To enable it in the current project,
-go to "File→Settings...→google-java-format Settings" and check the "Enable"
-checkbox.
+go to "File→Settings...→google-java-format Settings" (or
+"IntelliJ IDEA→Preferences...→Other Settings→google-java-format Settings" on
+macOS) and check the "Enable google-java-format" checkbox.
 
 To enable it by default in new projects, use "File→Other Settings→Default
 Settings...".


### PR DESCRIPTION
This PR updates the `idea_plugin/README.md` instructions to reflect the menu layout on the macOS version of IntelliJ IDEA.

It also changes the checkbox name from "Enable" to "Enable google-java-format", since that's the full checkbox label in the current (2017.2.5) version of IDEA (in both macOS and Windows).