### PR TITLE
CONTRIBUTING.md: Capitalize "GitHub" the way GitHub does

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ frustration later on.
 
 ### Code reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use GitHub pull requests for this purpose.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than


### PR DESCRIPTION
This PR is a minor style nitpick that capitalizes "GitHub" in `CONTRIBUTING.md` the way GitHub itself styles it.

Looks like this is the only place in this project where it occurs.

```
$ grep -r Github *
CONTRIBUTING.md:use Github pull requests for this purpose.
$ grep -r GitHub *
pom.xml:    <system>GitHub Issues</system>
$
```