### PR TITLE
Don't introduce a space for //noinspection

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -115,10 +115,10 @@ public final class JavaCommentsHelper implements CommentsHelper {
         // If it is `//noinspection` then don't add a space.  `//noinspection` is
         // used for single-line suppressions by both IntelliJ and Android Lint,
         // and for now there is no good alternative.
-        if ((line.length() > length + 12)
-            && line.substring(length,length+12).equals("noinspection")) {
-          // do nothing
-        } else {
+        boolean hasNoSuppression =
+            (line.length() > length + 12)
+                && line.substring(length, length + 12).equals("noinspection");
+        if (!hasNoSuppression) {
           line = Strings.repeat("/", length) + " " + line.substring(length);
         }
       }
@@ -180,4 +180,3 @@ public final class JavaCommentsHelper implements CommentsHelper {
     return true;
   }
 }
-

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -115,10 +115,8 @@ public final class JavaCommentsHelper implements CommentsHelper {
         // If it is `//noinspection` then don't add a space.  `//noinspection` is
         // used for single-line suppressions by both IntelliJ and Android Lint,
         // and for now there is no good alternative.
-        boolean hasNoSuppression =
-            (line.length() > length + 12)
-                && line.substring(length, length + 12).equals("noinspection");
-        if (!hasNoSuppression) {
+        boolean hasNoInspection = line.regionMatches(length, "noinspection", 0, 12);
+        if (!hasNoInspection) {
           line = Strings.repeat("/", length) + " " + line.substring(length);
         }
       }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -112,7 +112,15 @@ public final class JavaCommentsHelper implements CommentsHelper {
       Matcher matcher = LINE_COMMENT_PREFIX.matcher(line);
       if (matcher.find()) {
         int length = matcher.group(1).length();
-        line = Strings.repeat("/", length) + " " + line.substring(length);
+        // If it is `//noinspection` then don't add a space.  `//noinspection` is
+        // used for single-line suppressions by both IntelliJ and Android Lint,
+        // and for now there is no good alternative.
+        if ((line.length() > length + 12)
+            && line.substring(length,length+12).equals("noinspection")) {
+          // do nothing
+        } else {
+          line = Strings.repeat("/", length) + " " + line.substring(length);
+        }
       }
       while (line.length() + column0 > options.maxLineLength()) {
         int idx = options.maxLineLength() - column0;

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
@@ -389,4 +389,15 @@ public final class FormatterTest {
                 + "  }\n"
                 + "}\n");
   }
+
+  @Test
+  public void testNoInjectedSpaceForSuppressionComment() throws Exception {
+    String input = "class T {\n"
+            + "  public static void main(String[] args) {\n"
+            + "    //noinspection CheckResult\n"
+            + "    methodWhoseResultShouldBeChecked();\n"
+            + "  }\n"
+            + "}\n";
+    assertThat(new Formatter().formatSource(input)).isEqualTo(input);
+  }
 }


### PR DESCRIPTION
This reformatting breaks Android Lint and IntelliJ suppressions

Fixes #202