### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ Your starting point should be the instance methods of
 
 ## Building from source
 
-    mvn install
+    cd google-java-format/
+    mvn -f core/pom.xml install
 
 ## Contributing
 


### PR DESCRIPTION
`mvn install` won't work if you run it from the `core` directory (which is most intuitive for people who use maven). So I'm clarifying where to run it from. Otherwise you get 
```
[ERROR] Failed to execute goal com.google.code.maven-replacer-plugin:replacer:1.5.3:replace (default) on project google-java-format: File 'core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatVersion.java.template' does not exist -> [Help 1]
```