### PR TITLE
Enable build matrix on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,20 @@ notifications:
     on_success: change
     on_failure: always
 
-jdk:
-  - oraclejdk8
-
-# TODO(cushon): fix JDK 9 build and enable
-#  - oraclejdk9
+matrix:
+  allow_failures:
+    - jdk: oraclejdk9
+    - env: JDK_RELEASE='10 Early-Access'
+  include:
+# JDK 8
+    - jdk: oraclejdk8
+      env: JDK_RELEASE='8'
+# JDK 9
+    - jdk: oraclejdk9
+      env: JDK_RELEASE='9'
+# JDK 10
+    - env: JDK_RELEASE='10 Early-Access'
+      before_install: unset _JAVA_OPTIONS && . ./scripts/install-jdk-10.sh
 
 # see https://github.com/travis-ci/travis-ci/issues/8408
 before_install:

--- a/scripts/install-jdk-10.sh
+++ b/scripts/install-jdk-10.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+JDK_FEATURE=10
+
+TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
+TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}-ea+}" # remove everything before the number
+TMP="${TMP%%<*}"                                        # remove everything after the number
+JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
+
+JDK_ARCHIVE=jdk-${JDK_FEATURE}-ea+${JDK_BUILD}_linux-x64_bin.tar.gz
+
+cd ~
+wget http://download.java.net/java/jdk${JDK_FEATURE}/archive/${JDK_BUILD}/binaries/${JDK_ARCHIVE}
+tar -xzf ${JDK_ARCHIVE}
+export JAVA_HOME=~/jdk-${JDK_FEATURE}
+export PATH=${JAVA_HOME}/bin:$PATH
+cd -
+
+java --version


### PR DESCRIPTION
Add build matrix with JDK 8, 9 and 10-ea and allow failures for 9 and 10.

See summary at https://travis-ci.org/google/google-java-format/builds/308634483