### PR TITLE
Set 'com.google.googlejavaformat' as automatic module name

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -143,6 +143,11 @@
                 true
               </addDefaultImplementationEntries>
             </manifest>
+            <manifestEntries>
+              <Automatic-Module-Name>
+                com.google.googlejavaformat
+              </Automatic-Module-Name>
+            </manifestEntries>
           </archive>
         </configuration>
       </plugin>


### PR DESCRIPTION
Claim `com.google.googlejavaformat` as `Automatic-Module-Name` in the JAR manifest.

Details:
http://branchandbound.net/blog/java/2017/12/automatic-module-name/

Module names already claimed by Google:
https://github.com/jodastephen/jpms-module-names/blob/master/generated/modules.md#google

Before name is set:
```
jar --describe-module --file google-java-format-1.5.jar

google.java.format@1.5 automatic
[...]
```

After name is set:
```
jar --describe-module --file google-java-format-1.6-SNAPSHOT.jar

com.google.googlejavaformat@1.6-SNAPSHOT automatic
requires java.base mandated
contains com.google.googlejavaformat
contains com.google.googlejavaformat.java
contains com.google.googlejavaformat.java.filer
contains com.google.googlejavaformat.java.javadoc
main-class com.google.googlejavaformat.java.Main
```