### PR TITLE
This adds an AOSP formatter to the Eclipse plugin. 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.googlejavaformat</groupId>
     <artifactId>google-java-format-parent</artifactId>
-    <version>1.6-SNAPSHOT</version>
+    <version>1.6</version>
   </parent>
 
   <artifactId>google-java-format</artifactId>

--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -16,27 +16,13 @@ package com.google.googlejavaformat.java;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
-import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
-import com.google.common.collect.TreeRangeSet;
-import com.google.common.io.CharSink;
-import com.google.common.io.CharSource;
-import com.google.errorprone.annotations.Immutable;
-import com.google.googlejavaformat.Doc;
-import com.google.googlejavaformat.DocBuilder;
-import com.google.googlejavaformat.FormattingError;
-import com.google.googlejavaformat.Newlines;
-import com.google.googlejavaformat.Op;
-import com.google.googlejavaformat.OpsBuilder;
 import java.io.IOError;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
 import org.openjdk.javax.tools.Diagnostic;
 import org.openjdk.javax.tools.DiagnosticCollector;
 import org.openjdk.javax.tools.DiagnosticListener;
@@ -52,6 +38,22 @@ import org.openjdk.tools.javac.util.Context;
 import org.openjdk.tools.javac.util.Log;
 import org.openjdk.tools.javac.util.Options;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Range;
+import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
+import com.google.common.io.CharSink;
+import com.google.common.io.CharSource;
+import com.google.errorprone.annotations.Immutable;
+import com.google.googlejavaformat.Doc;
+import com.google.googlejavaformat.DocBuilder;
+import com.google.googlejavaformat.FormattingError;
+import com.google.googlejavaformat.Newlines;
+import com.google.googlejavaformat.Op;
+import com.google.googlejavaformat.OpsBuilder;
+
 /**
  * This is google-java-format, a new Java formatter that follows the Google Java Style Guide quite
  * precisely---to the letter and to the spirit.
@@ -65,8 +67,8 @@ import org.openjdk.tools.javac.util.Options;
  * is a final EOF token to hold final comments.
  *
  * <p>The formatter walks the AST to generate a Greg Nelson/Derek Oppen-style list of formatting
- * {@link Op}s [1--2] that then generates a structured {@link Doc}. Each AST node type has a visitor
- * to emit a sequence of {@link Op}s for the node.
+ * {@link Op}s [1--2] that then generates a structured {@link Doc} . Each AST node type has a
+ * visitor to emit a sequence of {@link Op}s for the node.
  *
  * <p>Some data-structure operations are easier in the list of {@link Op}s, while others become
  * easier in the {@link Doc}. The {@link Op}s are walked to attach the comments. As the {@link Op}s
@@ -100,9 +102,14 @@ public final class Formatter {
     this.options = options;
   }
 
+  /** @return The options used for this formatter. */
+  public JavaFormatterOptions options() {
+    return options;
+  }
+
   /**
    * Construct a {@code Formatter} given a Java compilation unit. Parses the code; builds a {@link
-   * JavaInput} and the corresponding {@link JavaOutput}.
+   * JavaInput} and the corresponding {@link JavaOutput} .
    *
    * @param javaInput the input, a Java compilation unit
    * @param javaOutput the {@link JavaOutput}
@@ -114,7 +121,8 @@ public final class Formatter {
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     context.put(DiagnosticListener.class, diagnostics);
     Options.instance(context).put("allowStringFolding", "false");
-    // TODO(cushon): this should default to the latest supported source level, remove this after
+    // TODO(cushon): this should default to the latest supported source
+    // level, remove this after
     // backing out
     // https://github.com/google/error-prone-javac/commit/c97f34ddd2308302587ce2de6d0c984836ea5b9f
     Options.instance(context).put(Option.SOURCE, "9");
@@ -138,9 +146,9 @@ public final class Formatter {
     JavacParser parser =
         parserFactory.newParser(
             javaInput.getText(),
-            /*keepDocComments=*/ true,
-            /*keepEndPos=*/ true,
-            /*keepLineMap=*/ true);
+            /* keepDocComments= */ true,
+            /* keepEndPos= */ true,
+            /* keepLineMap= */ true);
     unit = parser.parseCompilationUnit();
     unit.sourcefile = source;
 
@@ -168,7 +176,8 @@ public final class Formatter {
     }
     switch (input.getCode()) {
       case "compiler.err.invalid.meth.decl.ret.type.req":
-        // accept constructor-like method declarations that don't match the name of their
+        // accept constructor-like method declarations that don't match the
+        // name of their
         // enclosing class
         return false;
       default:
@@ -210,8 +219,8 @@ public final class Formatter {
    * @param input the input string
    * @return the output string
    * @throws FormatterException if the input string cannot be parsed
-   * @see <a
-   *     href="https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing">
+   * @see <a href=
+   *     "https://google.github.io/styleguide/javaguide.html#s3.3.3-import-ordering-and-spacing">
    *     Google Java Style Guide - 3.3.3 Import ordering and spacing</a>
    */
   public String formatSourceAndFixImports(String input) throws FormatterException {
@@ -246,8 +255,10 @@ public final class Formatter {
       String input, Collection<Range<Integer>> characterRanges) throws FormatterException {
     JavaInput javaInput = new JavaInput(input);
 
-    // TODO(cushon): this is only safe because the modifier ordering doesn't affect whitespace,
-    // and doesn't change the replacements that are output. This is not true in general for
+    // TODO(cushon): this is only safe because the modifier ordering doesn't
+    // affect whitespace,
+    // and doesn't change the replacements that are output. This is not true
+    // in general for
     // 'de-linting' changes (e.g. import ordering).
     javaInput = ModifierOrderer.reorderModifiers(javaInput, characterRanges);
 
@@ -276,7 +287,8 @@ public final class Formatter {
     for (Range<Integer> lineRange :
         lineRanges.subRangeSet(Range.closedOpen(0, lines.size() - 1)).asRanges()) {
       int lineStart = lines.get(lineRange.lowerEndpoint());
-      // Exclude the trailing newline. This isn't strictly necessary, but handling blank lines
+      // Exclude the trailing newline. This isn't strictly necessary, but
+      // handling blank lines
       // as empty ranges is convenient.
       int lineEnd = lines.get(lineRange.upperEndpoint()) - 1;
       Range<Integer> range = Range.closedOpen(lineStart, lineEnd);

--- a/core/src/main/java/com/google/googlejavaformat/java/SnippetFormatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/SnippetFormatter.java
@@ -14,14 +14,15 @@
 
 package com.google.googlejavaformat.java;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import java.util.ArrayList;
-import java.util.List;
 
 /** Formats a subset of a compilation unit. */
 public class SnippetFormatter {
@@ -56,16 +57,25 @@ public class SnippetFormatter {
     }
   }
 
-  private static final int INDENTATION_SIZE = 2;
-  private final Formatter formatter = new Formatter();
+  private static final int SPACES_PER_INDENT_LEVEL = 2;
+  private final Formatter formatter;
   private static final CharMatcher NOT_WHITESPACE = CharMatcher.whitespace().negate();
+
+  public SnippetFormatter() {
+    this(JavaFormatterOptions.defaultOptions());
+  }
+
+  public SnippetFormatter(JavaFormatterOptions options) {
+    Preconditions.checkNotNull(options);
+    this.formatter = new Formatter(options);
+  }
 
   public String createIndentationString(int indentationLevel) {
     Preconditions.checkArgument(
         indentationLevel >= 0,
         "Indentation level cannot be less than zero. Given: %s",
         indentationLevel);
-    int spaces = indentationLevel * INDENTATION_SIZE;
+    int spaces = indentationLevel * indentationSize();
     StringBuilder buf = new StringBuilder(spaces);
     for (int i = 0; i < spaces; i++) {
       buf.append(' ');
@@ -134,9 +144,10 @@ public class SnippetFormatter {
           "source = \"" + source + "\", replacement = \"" + replacement + "\"");
     }
     /*
-     * In the past we seemed to have problems touching non-whitespace text in the formatter, even
-     * just replacing some code with itself.  Retrospective attempts to reproduce this have failed,
-     * but this may be an issue for future changes.
+     * In the past we seemed to have problems touching non-whitespace text
+     * in the formatter, even just replacing some code with itself.
+     * Retrospective attempts to reproduce this have failed, but this may be
+     * an issue for future changes.
      */
     List<Replacement> replacements = new ArrayList<>();
     int i = NOT_WHITESPACE.indexIn(source);
@@ -163,8 +174,9 @@ public class SnippetFormatter {
 
   private SnippetWrapper snippetWrapper(SnippetKind kind, String source, int initialIndent) {
     /*
-     * Synthesize a dummy class around the code snippet provided by Eclipse.  The dummy class is
-     * correctly formatted -- the blocks use correct indentation, etc.
+     * Synthesize a dummy class around the code snippet provided by Eclipse.
+     * The dummy class is correctly formatted -- the blocks use correct
+     * indentation, etc.
      */
     switch (kind) {
       case COMPILATION_UNIT:
@@ -214,5 +226,9 @@ public class SnippetFormatter {
       default:
         throw new IllegalArgumentException("Unknown snippet kind: " + kind);
     }
+  }
+
+  private int indentationSize() {
+    return SPACES_PER_INDENT_LEVEL * formatter.options().indentationMultiplier();
   }
 }

--- a/eclipse_plugin/META-INF/MANIFEST.MF
+++ b/eclipse_plugin/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: google-java-format
 Bundle-SymbolicName: google-java-format-eclipse-plugin;singleton:=true
-Bundle-Version: 1.5.0
+Bundle-Version: 1.6.0
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.jface,
@@ -11,5 +11,5 @@ Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.equinox.common
 Bundle-ClassPath: .,
  lib/guava-22.0.jar,
- lib/javac-shaded-9-dev-r4023-3.jar,
- lib/google-java-format-1.5.jar
+ lib/javac-shaded-9+181-r4173-1.jar,
+ lib/google-java-format-1.6.jar

--- a/eclipse_plugin/build.properties
+++ b/eclipse_plugin/build.properties
@@ -3,6 +3,6 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/javac-shaded-9-dev-r4023-3.jar,\
+               lib/javac-shaded-9+181-r4173-1.jar,\
                lib/guava-22.0.jar,\
-               lib/google-java-format-1.5.jar
+               lib/google-java-format-1.6.jar

--- a/eclipse_plugin/plugin.xml
+++ b/eclipse_plugin/plugin.xml
@@ -5,7 +5,12 @@
    <javaFormatter
          class="com.google.googlejavaformat.java.GoogleJavaFormatter"
          id="com.google.googlejavaformat.java.GoogleJavaFormatter"
-         name="google-java-format 1.4">
+         name="google-java-format 1.6">
+   </javaFormatter>
+   <javaFormatter
+         class="com.google.googlejavaformat.java.AospJavaFormatter"
+         id="com.google.googlejavaformat.java.AospJavaFormatter"
+         name="aosp-java-format 1.6">
    </javaFormatter>
    </extension>
 </plugin>

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -20,11 +20,11 @@
   <parent>
     <groupId>com.google.googlejavaformat</groupId>
     <artifactId>google-java-format-parent</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
   </parent>
 
   <artifactId>google-java-format-eclipse-plugin</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
   <packaging>eclipse-plugin</packaging>
   <name>google-java-format Plugin for Eclipse 4.5+</name>
 
@@ -48,7 +48,7 @@
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>1.5</version>
+      <version>${project.parent.version}</version>
     </dependency>
   </dependencies>
 

--- a/eclipse_plugin/src/com/google/googlejavaformat/java/AbstractJavaFormatter.java
+++ b/eclipse_plugin/src/com/google/googlejavaformat/java/AbstractJavaFormatter.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.googlejavaformat.java;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.text.edits.MultiTextEdit;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.eclipse.text.edits.TextEdit;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Range;
+import com.google.googlejavaformat.java.SnippetFormatter.SnippetKind;
+
+/**
+ * This class provides the bulk of the logic to run java formatter within Eclipse. It provides the
+ * ability to formatting options to be specified.
+ */
+public abstract class AbstractJavaFormatter extends CodeFormatter {
+
+  @Override
+  public TextEdit format(
+      int kind, String source, int offset, int length, int indentationLevel, String lineSeparator) {
+    IRegion[] regions = new IRegion[] {new Region(offset, length)};
+    return formatInternal(kind, source, regions, indentationLevel);
+  }
+
+  @Override
+  public TextEdit format(
+      int kind, String source, IRegion[] regions, int indentationLevel, String lineSeparator) {
+    return formatInternal(kind, source, regions, indentationLevel);
+  }
+
+  @Override
+  public String createIndentationString(int indentationLevel) {
+    Preconditions.checkArgument(
+        indentationLevel >= 0,
+        "Indentation level cannot be less than zero. Given: %s",
+        indentationLevel);
+    int spaces = indentationLevel * indentationSize();
+    StringBuilder buf = new StringBuilder(spaces);
+    for (int i = 0; i < spaces; i++) {
+      buf.append(' ');
+    }
+    return buf.toString();
+  }
+
+  /** Runs the Google Java formatter on the given source, with only the given ranges specified. */
+  private TextEdit formatInternal(int kind, String source, IRegion[] regions, int initialIndent) {
+    try {
+      boolean includeComments =
+          (kind & CodeFormatter.F_INCLUDE_COMMENTS) == CodeFormatter.F_INCLUDE_COMMENTS;
+      kind &= ~CodeFormatter.F_INCLUDE_COMMENTS;
+      SnippetKind snippetKind;
+      switch (kind) {
+        case ASTParser.K_EXPRESSION:
+          snippetKind = SnippetKind.EXPRESSION;
+          break;
+        case ASTParser.K_STATEMENTS:
+          snippetKind = SnippetKind.STATEMENTS;
+          break;
+        case ASTParser.K_CLASS_BODY_DECLARATIONS:
+          snippetKind = SnippetKind.CLASS_BODY_DECLARATIONS;
+          break;
+        case ASTParser.K_COMPILATION_UNIT:
+          snippetKind = SnippetKind.COMPILATION_UNIT;
+          break;
+        default:
+          throw new IllegalArgumentException(String.format("Unknown snippet kind: %d", kind));
+      }
+      List<Replacement> replacements =
+          createSnippetFormatter()
+              .format(
+                  snippetKind, source, rangesFromRegions(regions), initialIndent, includeComments);
+      if (idempotent(source, regions, replacements)) {
+        // Do not create edits if there's no diff.
+        return null;
+      }
+      // Convert replacements to text edits.
+      return editFromReplacements(replacements);
+    } catch (IllegalArgumentException | FormatterException exception) {
+      // Do not format on errors.
+      return null;
+    }
+  }
+
+  private List<Range<Integer>> rangesFromRegions(IRegion[] regions) {
+    List<Range<Integer>> ranges = new ArrayList<>();
+    for (IRegion region : regions) {
+      ranges.add(Range.closedOpen(region.getOffset(), region.getOffset() + region.getLength()));
+    }
+    return ranges;
+  }
+
+  /** @return {@code true} if input and output texts are equal, else {@code false}. */
+  private boolean idempotent(String source, IRegion[] regions, List<Replacement> replacements) {
+    // This implementation only checks for single replacement.
+    if (replacements.size() == 1) {
+      Replacement replacement = replacements.get(0);
+      String output = replacement.getReplacementString();
+      // Entire source case: input = output, nothing changed.
+      if (output.equals(source)) {
+        return true;
+      }
+      // Single region and single replacement case: if they are equal,
+      // nothing changed.
+      if (regions.length == 1) {
+        Range<Integer> range = replacement.getReplaceRange();
+        String snippet = source.substring(range.lowerEndpoint(), range.upperEndpoint());
+        if (output.equals(snippet)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private TextEdit editFromReplacements(List<Replacement> replacements) {
+    // Split the replacements that cross line boundaries.
+    TextEdit edit = new MultiTextEdit();
+    for (Replacement replacement : replacements) {
+      Range<Integer> replaceRange = replacement.getReplaceRange();
+      edit.addChild(
+          new ReplaceEdit(
+              replaceRange.lowerEndpoint(),
+              replaceRange.upperEndpoint() - replaceRange.lowerEndpoint(),
+              replacement.getReplacementString()));
+    }
+    return edit;
+  }
+
+  /**
+   * Create an instance of the formatter that will be used. This method should be aligned with
+   * {@link #indentationSize()} such that the indentation size corresponds with the indent level of
+   * the format options used to create the snippet formatter.
+   */
+  protected abstract SnippetFormatter createSnippetFormatter();
+
+  /**
+   * The number of spaces per indent level. This method should be aligned with {@link
+   * #createSnippetFormatter()} such that the indentation size corresponds with the indent level of
+   * the format options used to create the snippet formatter.
+   */
+  protected abstract int indentationSize();
+}

--- a/eclipse_plugin/src/com/google/googlejavaformat/java/AospJavaFormatter.java
+++ b/eclipse_plugin/src/com/google/googlejavaformat/java/AospJavaFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google Inc.
+ * Copyright 2018 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,19 +11,20 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.google.googlejavaformat.java;
 
-/** Runs the Google Java formatter on the given code. */
-public class GoogleJavaFormatter extends AbstractJavaFormatter {
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+
+/** Runs the AOSP Java formatter on the given code. */
+public class AospJavaFormatter extends AbstractJavaFormatter {
 
   @Override
   protected SnippetFormatter createSnippetFormatter() {
-    return new SnippetFormatter();
+    return new SnippetFormatter(JavaFormatterOptions.builder().style(Style.AOSP).build());
   }
 
   @Override
   protected int indentationSize() {
-    return 2;
+    return 4;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -28,14 +28,15 @@
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.6</version>
 
   <modules>
     <module>core</module>
     <!-- google-java-format#24
     <module>idea_plugin</module>
-    <module>eclipse_plugin</module>
     -->
+    <!-- TODO COMMENT OUT -->
+    <module>eclipse_plugin</module>
   </modules>
 
   <name>Google Java Format Parent</name>


### PR DESCRIPTION
This is achieved by creating two different Eclipse Java Formatter implementations
that are selectable in the _Java Code Style > Formatter_ preferences.
The `google-java-format` acts just the same. A new `aosp-java-format`
enables AOSP options.

Internally this is achieved by giving the SnippetFormatter the ability
to accept `JavaFormatterOptions`.