### PR TITLE
Moe Sync

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/ImportOrderer.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/ImportOrderer.java
@@ -17,6 +17,7 @@ import static com.google.common.collect.Iterables.getLast;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
@@ -242,7 +243,7 @@ public class ImportOrderer {
 
   // Produces the sorted output based on the imports we have scanned.
   private String reorderedImportsString(ImmutableSortedSet<Import> imports) {
-    assert !imports.isEmpty();
+    Preconditions.checkArgument(!imports.isEmpty(), "imports");
 
     Import firstImport = imports.iterator().next();
 

--- a/scripts/install-jdk-10.sh
+++ b/scripts/install-jdk-10.sh
@@ -6,11 +6,11 @@ set -e
 JDK_FEATURE=10
 
 TMP=$(curl -L jdk.java.net/${JDK_FEATURE})
-TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}-ea+}" # remove everything before the number
+TMP="${TMP#*Most recent build: jdk-${JDK_FEATURE}+}" # remove everything before the number
 TMP="${TMP%%<*}"                                        # remove everything after the number
 JDK_BUILD="$(echo -e "${TMP}" | tr -d '[:space:]')"     # remove all whitespace
 
-JDK_ARCHIVE=jdk-${JDK_FEATURE}-ea+${JDK_BUILD}_linux-x64_bin.tar.gz
+JDK_ARCHIVE=jdk-${JDK_FEATURE}+${JDK_BUILD}_linux-x64_bin.tar.gz
 
 cd ~
 wget http://download.java.net/java/jdk${JDK_FEATURE}/archive/${JDK_BUILD}/BCL/${JDK_ARCHIVE}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Drop `-ea` as JDK 10 is now a release candidate

Fixes #253

d83b0cf0dd778d507bb584f1ad39b609d64ca8fb

-------

<p> Make google-java-format stop using "assert." Use Preconditions instead.

bf7b7574da76620929333c0dd2f6066f0635037d