### PR TITLE
Update idea plugin to 1.6

### DIFF
--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -29,7 +29,7 @@ repositories {
 }
 
 ext {
-  googleJavaFormatVersion = '1.5'
+  googleJavaFormatVersion = '1.6'
 }
 
 apply plugin: 'org.jetbrains.intellij'


### PR DESCRIPTION
Update the idea plugin to 1.6

Is `idea_plugin/resources/META-INF/plugin.xml` still used? It has old configuration which appears to have been replaced with a build step.
https://github.com/google/google-java-format/blob/7db08b563c4c472a459558daa313f0e31639370d/idea_plugin/resources/META-INF/plugin.xml#L16
https://github.com/google/google-java-format/blob/09b13dc058d3ad0022f48c38081a4306c3e09d12/idea_plugin/build.gradle#L45-L50