### PR TITLE
Remove unused import statement

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatVersion.java.template
+++ b/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatVersion.java.template
@@ -14,8 +14,6 @@
 
 package com.google.googlejavaformat.java;
 
-import java.util.Optional;
-
 class GoogleJavaFormatVersion {
 
   static String version() {


### PR DESCRIPTION
`java.util.Optional` is no longer used by `GoogleJavaFormatVersion`.