### PR TITLE
Very simple Dockerfile based on openjdk:alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:alpine
+
+RUN mkdir -p /app
+WORKDIR /app
+
+ADD https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-1.6-all-deps.jar /app/google-java-format.jar
+
+ENTRYPOINT ["/usr/bin/java", "-jar", "/app/google-java-format.jar"]


### PR DESCRIPTION
Very basic, but easy implementation that could be pushed to a docker repo and utilized by others.