### PR TITLE
Update the google-java-format plugin to support all Intellij 2018.x builds.

### DIFF
--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "0.3.2"
+  id "org.jetbrains.intellij" version "0.3.11"
 }
 
 repositories {
@@ -40,6 +40,7 @@ patchPluginXml {
                       "the plugin uses version ${googleJavaFormatVersion} of the tool."
   version = "${googleJavaFormatVersion}.1"
   sinceBuild = '173'
+  untilBuild = '189'
 }
 
 publishPlugin {


### PR DESCRIPTION
* update `org.jetbrains.intellij` Gradle plugin to latest version for compatibility with latest Gradle versions.
* mark Intellij plugin as compatible with all `2018.x` Intellij versions.

Fixes https://github.com/google/google-java-format/issues/306