### PR TITLE
Moe Sync

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.googlejavaformat</groupId>
     <artifactId>google-java-format-parent</artifactId>
-    <version>1.8-SNAPSHOT</version>
+    <version>1.7-SNAPSHOT</version>
   </parent>
 
   <artifactId>google-java-format</artifactId>

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -1538,6 +1538,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       ImmutableSet.of(
           "at",
           "atConfig",
+          "atDebug",
           "atFine",
           "atFiner",
           "atFinest",

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -383,6 +383,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
   private void dropEmptyDeclarations() {
     if (builder.peekToken().equals(Optional.of(";"))) {
       while (builder.peekToken().equals(Optional.of(";"))) {
+        builder.forcedBreak();
         markForPartialFormat();
         token(";");
       }

--- a/core/src/test/java/com/google/googlejavaformat/java/PartialFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/PartialFormattingTest.java
@@ -1776,4 +1776,24 @@ public final class PartialFormattingTest {
     String output = doGetFormatReplacements(input, idx, idx + 1);
     assertThat(output).isEqualTo(expectedOutput);
   }
+
+  @Test
+  public void b117602702() throws Exception {
+    String input =
+        lines(
+            "class Foo {", //
+            "private Foo () {};",
+            "}",
+            "");
+    String expectedOutput =
+        lines(
+            "class Foo {", //
+            "  private Foo() {}",
+            "  ;",
+            "}",
+            "");
+
+    String output = runFormatter(input, new String[] {"-offset", "13", "-length", "1"});
+    assertThat(output).isEqualTo(expectedOutput);
+  }
 }

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B126411718.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B126411718.input
@@ -1,0 +1,10 @@
+class B126411718 {
+  {
+    logger
+        .atDebug()
+        .log(
+            "Scratch Session Cleaner exiting. Number of deleted sessions: %d, names: %s",
+            deletedPersistentNames.size(),
+            deletedPersistentNames);
+  }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B126411718.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B126411718.output
@@ -1,0 +1,7 @@
+class B126411718 {
+  {
+    logger.atDebug().log(
+        "Scratch Session Cleaner exiting. Number of deleted sessions: %d, names: %s",
+        deletedPersistentNames.size(), deletedPersistentNames);
+  }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B21647014.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B21647014.output
@@ -1,12 +1,22 @@
 package test;
 
-import java.util.List;;;
+import java.util.List;
+;
+;
 
-class Test {;
-  public int x = 42;;;;;
+class Test {
+  ;
+  public int x = 42;
+  ;
+  ;
+  ;
+  ;
 
   {
     int x = 1;
-    ;;
-  };
-};
+    ;
+    ;
+  }
+  ;
+}
+;

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B25811323.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B25811323.output
@@ -1,5 +1,6 @@
 class B25811323 {
   void f() {
-    class Inner {};
+    class Inner {}
+    ;
   }
 }

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B28788559.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B28788559.output
@@ -1,4 +1,5 @@
-import a.A;;
+import a.A;
+;
 import b.B;
 
 class Test {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/E.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/E.output
@@ -67,7 +67,11 @@ class E<T> {
   }
 
   int f(int value) {
-    ;;;;;
+    ;
+    ;
+    ;
+    ;
+    ;
     for (Integer x :
         ImmutableList.<Integer>of(
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) {}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/i281.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/i281.output
@@ -6,15 +6,18 @@ public enum Empty {
 
 public enum Empty {
   ;
-  ;;
+  ;
+  ;
 }
 
 public enum Empty {
   ; // comment
-  ;;
+  ;
+  ;
 }
 
 public enum Empty {
   ;
-  ;; // comment
+  ;
+  ; // comment
 }

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "0.3.11"
+  id "org.jetbrains.intellij" version "0.4.4"
 }
 
 repositories {
@@ -32,19 +32,18 @@ apply plugin: 'java'
 intellij {
   pluginName = "google-java-format"
   updateSinceUntilBuild = true
-  version = "2018.3.2"
+  version = "191.5849.21"
 }
 
 patchPluginXml {
   pluginDescription = "Formats source code using the google-java-format tool. This version of " +
                       "the plugin uses version ${googleJavaFormatVersion} of the tool."
-  version = "${googleJavaFormatVersion}.0.0"
+  version = "${googleJavaFormatVersion}.0.1"
   sinceBuild = '173'
 }
 
 publishPlugin {
-  username = project.ext.properties.jetbrainsPluginRepoUsername
-  password = project.ext.properties.jetbrainsPluginRepoPassword
+  token = project.ext.properties.jetbrainsPluginRepoToken
 }
 
 sourceSets {

--- a/idea_plugin/resources/META-INF/plugin.xml
+++ b/idea_plugin/resources/META-INF/plugin.xml
@@ -12,15 +12,10 @@
 
   <change-notes><![CDATA[
     <dl>
+      <dt>1.7.0.1</dt>
+      <dd>Added support for 2019.1 IDEs.</dd>
       <dt>1.7.0.0</dt>
       <dd>Upgraded to google-java-format 1.7.</dd>
-      <dt>1.6.2</dt>
-      <dd>Add support for 2018.3 IDEs.</dd>
-      <dt>1.6.1</dt>
-      <dd>Reverted the default to disabled. A notification will be presented the first time you
-        open a project asking if you want to enable google-java-format for that project.</dd>
-      <dt>1.6.0</dt>
-      <dd>Upgraded to google-java-format 1.6. Enabled the plugin by default.</dd>
     </dl>
   ]]></change-notes>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.8-SNAPSHOT</version>
+  <version>1.7-SNAPSHOT</version>
 
   <modules>
     <module>core</module>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Put empty class and member declarations on their own line

Per JLS 7.6 and 8.2 `;` is a valid empty top-level type or class member
declaration. This change puts it on its own line, instead of adding it
at the end of the preceding line.

Omitting the `;` is recommended: the goal of this change is just avoid a
partial formatting bug, and to call attention to the unnecessary element.

965411cdcb68e6b9abfcd3c023acbd19ce4190d8

-------

<p> Recognize atDebug methods in flogger heuristic

4cc87e48ef3fe13ccd8e9945db9ea2e38e996100

-------

<p> Add support for JetBrains 2019.1 IDEs.

225547d440f483f18bfd3e7dba8e3a675b4d8677