### PR TITLE
Moe Sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 and run it with:
 
 ```
-java -jar /path/to/google-java-format-1.6-all-deps.jar <options> [files...]
+java -jar /path/to/google-java-format-1.7-all-deps.jar <options> [files...]
 ```
 
 The formatter can act on whole files, on limited lines (`--lines`), on specific
@@ -92,7 +92,7 @@ configuration.
 <dependency>
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format</artifactId>
-  <version>1.6</version>
+  <version>1.7</version>
 </dependency>
 ```
 
@@ -100,7 +100,7 @@ configuration.
 
 ```groovy
 dependencies {
-  compile 'com.google.googlejavaformat:google-java-format:1.6'
+  compile 'com.google.googlejavaformat:google-java-format:1.7'
 }
 ```
 

--- a/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
@@ -46,7 +46,9 @@ import org.openjdk.javax.tools.SimpleJavaFileObject;
 import org.openjdk.javax.tools.StandardLocation;
 import org.openjdk.source.tree.BinaryTree;
 import org.openjdk.source.tree.LiteralTree;
+import org.openjdk.source.tree.MemberSelectTree;
 import org.openjdk.source.tree.Tree;
+import org.openjdk.source.tree.Tree.Kind;
 import org.openjdk.source.util.TreePath;
 import org.openjdk.source.util.TreePathScanner;
 import org.openjdk.tools.javac.file.JavacFileManager;
@@ -83,7 +85,12 @@ public final class StringWrapper {
     new TreePathScanner<Void, Void>() {
       @Override
       public Void visitLiteral(LiteralTree literalTree, Void aVoid) {
-        if (literalTree.getKind() != Tree.Kind.STRING_LITERAL) {
+        if (literalTree.getKind() != Kind.STRING_LITERAL) {
+          return null;
+        }
+        Tree parent = getCurrentPath().getParentPath().getLeaf();
+        if (parent instanceof MemberSelectTree
+            && ((MemberSelectTree) parent).getExpression().equals(literalTree)) {
           return null;
         }
         int startPosition = getStartPosition(literalTree);
@@ -146,8 +153,9 @@ public final class StringWrapper {
       if (!expected.equals(actual)) {
         throw new FormatterException(
             String.format(
-                "Something has gone terribly wrong. Please file a bug.\n\n"
-                    + "=== Actual: ===\n%s\n=== Expected: ===\n%s\n",
+                "Something has gone terribly wrong. Please file a bug: "
+                    + "https://github.com/google/google-java-format/issues/new"
+                    + "\n\n=== Actual: ===\n%s\n=== Expected: ===\n%s\n",
                 actual, expected));
       }
     }

--- a/core/src/test/java/com/google/googlejavaformat/java/StringWrapperIntegrationTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/StringWrapperIntegrationTest.java
@@ -348,6 +348,23 @@ public class StringWrapperIntegrationTest {
           "}",
         }
       },
+      {
+        {
+          "class T {", //
+          "  byte[] bytes =",
+          "      \"one long incredibly unbroken sentence moving from topic to topic so that no-one"
+              + " had a chance to interrupt\".getBytes();",
+          "}"
+        },
+        {
+          "class T {", //
+          "  byte[] bytes =",
+          "      \"one long incredibly unbroken sentence moving from topic to topic so that no-one"
+              + " had a chance to interrupt\"",
+          "          .getBytes();",
+          "}"
+        },
+      },
     };
     return Arrays.stream(inputsAndOutputs)
         .map(


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Don't reflow string literals used as the LHS of a select

to avoid issues with precedence, e.g. we'd need to add parens to
reflow `"foo bar".getBytes()`.

2e34158fbe6cd34737ad7b405d37e641150f0e77

-------

<p> Update README.md to refer to 1.7.

Fixes #343,#352,#350

41271ce6b3bdd274bdaf447154e2ec14a773dee6