### PR TITLE
Moe Sync

### DIFF
--- a/core/src/test/java/com/google/googlejavaformat/java/PartialFormattingTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/PartialFormattingTest.java
@@ -592,7 +592,10 @@ public final class PartialFormattingTest {
             "    // No maxResults",
             "    assertThat(achievementFirstPartyHelper.listDefinitionsByApplication(",
             "            STUB_GAIA_ID, STUB_APPLICATION_ID, Optional.<Integer>absent(),",
-            "            Optional.<String>absent()).getAchievements()).containsExactly(createExpectedDefinition(1), createIncrementalExpectedDefinition(2), createExpectedDefinition(3), createIncrementalExpectedDefinition(4)).inOrder();",
+            "           "
+                + " Optional.<String>absent()).getAchievements()).containsExactly(createExpectedDefinition(1),"
+                + " createIncrementalExpectedDefinition(2), createExpectedDefinition(3),"
+                + " createIncrementalExpectedDefinition(4)).inOrder();",
             "  }",
             "}",
             "",
@@ -892,7 +895,7 @@ public final class PartialFormattingTest {
       startPositions.add(replacement.getReplaceRange().lowerEndpoint());
     }
     assertThat(startPositions).hasSize(3);
-    assertThat(startPositions).isStrictlyOrdered();
+    assertThat(startPositions).isInStrictOrder();
   }
 
   @Test
@@ -920,7 +923,7 @@ public final class PartialFormattingTest {
       startPositions.add(replacement.getReplaceRange().lowerEndpoint());
     }
     assertThat(startPositions).hasSize(3);
-    assertThat(startPositions).isStrictlyOrdered();
+    assertThat(startPositions).isInStrictOrder();
   }
 
   private void testFormatLine(String input, String expectedOutput, int i) throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <java.version>1.8</java.version>
     <guava.version>27.0.1-jre</guava.version>
     <javac.version>9+181-r4173-1</javac.version>
-    <truth.version>0.44</truth.version>
+    <truth.version>0.45</truth.version>
     <jsr305.version>3.0.2</jsr305.version>
   </properties>
 


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update to Truth 0.45, and address deprecations.

Renames may include:
- containsAllOf => containsAtLeast
- containsAllIn => containsAtLeastElementsIn
- isSameAs => isSameInstanceAs
- isOrdered => isInOrder
- isStrictlyOrdered => isInStrictOrder

The other major change is to change custom subjects to extend raw Subject instead of supplying type parameters. The type parameters are being removed from Subject. This CL will temporarily produce rawtypes warnings, which will go away when I remove the type parameters (as soon as this batch of CLs is submitted).

Some CLs in this batch also migrate calls away from actualAsString(). Its literal replacement is `"<" + actual + ">"` (unless an object overrides actualCustomStringRepresentation()), but usually I've made a larger change, such as switching from an old-style "Not true that..." failure message to one generated with the Fact API. In that case, the new code usually contains a direct reference to this.actual (a field that I occasionally had to create). Another larger change I sometimes made is to switch from a manual check-and-fail approach to instead use check(...). And sometimes I just remove a withMessage() call that's no longer necessary now that the code uses check(...), or I introduce a check(...) call. (An assertion made with check(...) automatically includes the actual value from the original subject, so there's no need to set it again with withMessage().)

Finally, there's one CL in this batch in which I migrate a Correspondence subclass to instead use Correspondence.from.

f595b684bd0ff2183a023fffff7bc6268a637235