### PR TITLE
Moe Sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
     on_failure: always
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   - openjdk9
   - openjdk10
   - openjdk11

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
 
 jdk:
   - oraclejdk8
-  - oraclejdk9
+  - openjdk9
   - openjdk10
   - openjdk11
   - openjdk-ea

--- a/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/FormatFileCallable.java
@@ -41,11 +41,11 @@ class FormatFileCallable implements Callable<String> {
       return fixImports(input);
     }
 
-    String formatted =
-        new Formatter(options).formatSource(input, characterRanges(input).asRanges());
+    Formatter formatter = new Formatter(options);
+    String formatted = formatter.formatSource(input, characterRanges(input).asRanges());
     formatted = fixImports(formatted);
     if (parameters.reflowLongStrings()) {
-      formatted = StringWrapper.wrap(Formatter.MAX_LINE_LENGTH, formatted);
+      formatted = StringWrapper.wrap(Formatter.MAX_LINE_LENGTH, formatted, formatter);
     }
     return formatted;
   }

--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -219,7 +219,7 @@ public final class Formatter {
     input = ImportOrderer.reorderImports(input, options.style());
     input = RemoveUnusedImports.removeUnusedImports(input);
     String formatted = formatSource(input);
-    formatted = StringWrapper.wrap(formatted);
+    formatted = StringWrapper.wrap(formatted, this);
     return formatted;
   }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -454,9 +454,9 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
       Deque<ExpressionTree> dimExpressions = new ArrayDeque<>(node.getDimensions());
 
-      Deque<List<AnnotationTree>> annotations = new ArrayDeque<>();
+      Deque<List<? extends AnnotationTree>> annotations = new ArrayDeque<>();
       annotations.add(ImmutableList.copyOf(node.getAnnotations()));
-      annotations.addAll((List<List<AnnotationTree>>) node.getDimAnnotations());
+      annotations.addAll(node.getDimAnnotations());
       annotations.addAll(extractedDims.dims);
 
       scan(base, null);
@@ -578,7 +578,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     TypeWithDims extractedDims = DimensionHelpers.extractDims(node, SortedDims.YES);
     builder.open(plusFour);
     scan(extractedDims.node, null);
-    Deque<List<AnnotationTree>> dims = new ArrayDeque<>(extractedDims.dims);
+    Deque<List<? extends AnnotationTree>> dims = new ArrayDeque<>(extractedDims.dims);
     maybeAddDims(dims);
     Verify.verify(dims.isEmpty());
     builder.close();
@@ -1352,7 +1352,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
             annotations, Direction.VERTICAL, /* declarationAnnotationBreak= */ Optional.empty()));
 
     Tree baseReturnType = null;
-    Deque<List<AnnotationTree>> dims = null;
+    Deque<List<? extends AnnotationTree>> dims = null;
     if (node.getReturnType() != null) {
       TypeWithDims extractedDims =
           DimensionHelpers.extractDims(node.getReturnType(), SortedDims.YES);
@@ -3234,7 +3234,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       builder.blankLineWanted(BlankLineWanted.conditional(verticalAnnotationBreak));
     }
 
-    Deque<List<AnnotationTree>> dims =
+    Deque<List<? extends AnnotationTree>> dims =
         new ArrayDeque<>(
             typeWithDims.isPresent() ? typeWithDims.get().dims : Collections.emptyList());
     int baseDims = 0;
@@ -3321,7 +3321,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     return baseDims;
   }
 
-  private void maybeAddDims(Deque<List<AnnotationTree>> annotations) {
+  private void maybeAddDims(Deque<List<? extends AnnotationTree>> annotations) {
     maybeAddDims(new ArrayDeque<>(), annotations);
   }
 
@@ -3338,7 +3338,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
    *     [[@A, @B], [@C]]} for {@code int @A [] @B @C []}
    */
   private void maybeAddDims(
-      Deque<ExpressionTree> dimExpressions, Deque<List<AnnotationTree>> annotations) {
+      Deque<ExpressionTree> dimExpressions, Deque<List<? extends AnnotationTree>> annotations) {
     boolean lastWasAnnotation = false;
     while (builder.peekToken().isPresent()) {
       switch (builder.peekToken().get()) {
@@ -3346,7 +3346,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
           if (annotations.isEmpty()) {
             return;
           }
-          List<AnnotationTree> dimAnnotations = annotations.removeFirst();
+          List<? extends AnnotationTree> dimAnnotations = annotations.removeFirst();
           if (dimAnnotations.isEmpty()) {
             continue;
           }
@@ -3396,7 +3396,7 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     builder.open(plusFour);
     builder.open(ZERO);
     TypeWithDims extractedDims = DimensionHelpers.extractDims(type, SortedDims.YES);
-    Deque<List<AnnotationTree>> dims = new ArrayDeque<>(extractedDims.dims);
+    Deque<List<? extends AnnotationTree>> dims = new ArrayDeque<>(extractedDims.dims);
     scan(extractedDims.node, null);
     int baseDims = dims.size();
     maybeAddDims(dims);

--- a/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
@@ -72,19 +72,6 @@ import org.openjdk.tools.javac.util.Options;
  */
 public class RemoveUnusedImports {
 
-  /**
-   * Configuration for javadoc-only imports.
-   *
-   * @deprecated This configuration is no longer supported and will be removed in the future.
-   */
-  @Deprecated
-  public enum JavadocOnlyImports {
-    /** Remove imports that are only used in javadoc, and fully qualify any {@code @link} tags. */
-    REMOVE,
-    /** Keep imports that are only used in javadoc. */
-    KEEP
-  }
-
   // Visits an AST, recording all simple names that could refer to imported
   // types and also any javadoc references that could refer to imported
   // types (`@link`, `@see`, `@throws`, etc.)
@@ -197,13 +184,6 @@ public class RemoveUnusedImports {
     }
   }
 
-  /** @deprecated use {@link removeUnusedImports(String)} instead. */
-  @Deprecated
-  public static String removeUnusedImports(
-      final String contents, JavadocOnlyImports javadocOnlyImports) throws FormatterException {
-    return removeUnusedImports(contents);
-  }
-
   public static String removeUnusedImports(final String contents) throws FormatterException {
     Context context = new Context();
     // TODO(cushon): this should default to the latest supported source level, same as in Formatter
@@ -276,17 +256,6 @@ public class RemoveUnusedImports {
         endPosition += sep.length();
       }
       replacements.put(Range.closedOpen(importTree.getStartPosition(), endPosition), "");
-      // fully qualify any javadoc references with the same simple name as a deleted
-      // non-static import
-      if (!importTree.isStatic()) {
-        for (Range<Integer> docRange : usedInJavadoc.get(simpleName)) {
-          if (docRange == null) {
-            continue;
-          }
-          String replaceWith = importTree.getQualifiedIdentifier().toString();
-          replacements.put(docRange, replaceWith);
-        }
-      }
     }
     return replacements;
   }
@@ -349,18 +318,6 @@ public class RemoveUnusedImports {
       }
       offset += replaceWith.length() - (range.upperEndpoint() - range.lowerEndpoint());
     }
-    String result = sb.toString();
-
-    // If there were any non-empty replaced ranges (e.g. javadoc), reformat the fixed regions.
-    // We could avoid formatting twice in --fix-imports=also mode, but that is not the default
-    // and removing imports won't usually affect javadoc.
-    if (!fixedRanges.isEmpty()) {
-      try {
-        result = new Formatter().formatSource(result, fixedRanges.asRanges());
-      } catch (FormatterException e) {
-        // javadoc reformatting is best-effort
-      }
-    }
-    return result;
+    return sb.toString();
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/Replacement.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Replacement.java
@@ -14,6 +14,9 @@
 
 package com.google.googlejavaformat.java;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Range;
 import java.util.Objects;
 
@@ -23,28 +26,20 @@ import java.util.Objects;
  * <p>google-java-format doesn't depend on AutoValue, to allow AutoValue to depend on
  * google-java-format.
  */
-public class Replacement {
+public final class Replacement {
 
   public static Replacement create(int startPosition, int endPosition, String replaceWith) {
+    checkArgument(startPosition >= 0, "startPosition must be non-negative");
+    checkArgument(startPosition <= endPosition, "startPosition cannot be after endPosition");
     return new Replacement(Range.closedOpen(startPosition, endPosition), replaceWith);
-  }
-
-  public static Replacement create(Range<Integer> range, String replaceWith) {
-    return new Replacement(range, replaceWith);
   }
 
   private final Range<Integer> replaceRange;
   private final String replacementString;
 
-  Replacement(Range<Integer> replaceRange, String replacementString) {
-    if (replaceRange == null) {
-      throw new NullPointerException("Null replaceRange");
-    }
-    this.replaceRange = replaceRange;
-    if (replacementString == null) {
-      throw new NullPointerException("Null replacementString");
-    }
-    this.replacementString = replacementString;
+  private Replacement(Range<Integer> replaceRange, String replacementString) {
+    this.replaceRange = checkNotNull(replaceRange, "Null replaceRange");
+    this.replacementString = checkNotNull(replacementString, "Null replacementString");
   }
 
   /** The range of characters in the original source to replace. */

--- a/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
@@ -62,19 +62,52 @@ import org.openjdk.tools.javac.util.Position;
 /** Wraps string literals that exceed the column limit. */
 public final class StringWrapper {
   /** Reflows long string literals in the given Java source code. */
-  public static String wrap(String input) throws FormatterException {
-    return StringWrapper.wrap(Formatter.MAX_LINE_LENGTH, input);
+  public static String wrap(String input, Formatter formatter) throws FormatterException {
+    return StringWrapper.wrap(Formatter.MAX_LINE_LENGTH, input, formatter);
   }
 
   /**
    * Reflows string literals in the given Java source code that extend past the given column limit.
    */
-  static String wrap(final int columnLimit, final String input) throws FormatterException {
+  static String wrap(final int columnLimit, String input, Formatter formatter)
+      throws FormatterException {
     if (!longLines(columnLimit, input)) {
       // fast path
       return input;
     }
 
+    TreeRangeMap<Integer, String> replacements = getReflowReplacements(columnLimit, input);
+    String firstPass = formatter.formatSource(input, replacements.asMapOfRanges().keySet());
+
+    if (!firstPass.equals(input)) {
+      // If formatting the replacement ranges resulted in a change, recalculate the replacements on
+      // the updated input.
+      input = firstPass;
+      replacements = getReflowReplacements(columnLimit, input);
+    }
+
+    String result = applyReplacements(input, replacements);
+
+    {
+      // We really don't want bugs in this pass to change the behaviour of programs we're
+      // formatting, so check that the pretty-printed AST is the same before and after reformatting.
+      String expected = parse(input, /* allowStringFolding= */ true).toString();
+      String actual = parse(result, /* allowStringFolding= */ true).toString();
+      if (!expected.equals(actual)) {
+        throw new FormatterException(
+            String.format(
+                "Something has gone terribly wrong. Please file a bug: "
+                    + "https://github.com/google/google-java-format/issues/new"
+                    + "\n\n=== Actual: ===\n%s\n=== Expected: ===\n%s\n",
+                actual, expected));
+      }
+    }
+
+    return result;
+  }
+
+  private static TreeRangeMap<Integer, String> getReflowReplacements(
+      int columnLimit, final String input) throws FormatterException {
     JCTree.JCCompilationUnit unit = parse(input, /* allowStringFolding= */ false);
     String separator = Newlines.guessLineSeparator(input);
 
@@ -137,24 +170,7 @@ public final class StringWrapper {
           Range.closedOpen(getStartPosition(flat.get(0)), getEndPosition(unit, getLast(flat))),
           reflow(separator, columnLimit, startColumn, trailing, components, first.get()));
     }
-    String result = applyReplacements(input, replacements);
-
-    {
-      // We really don't want bugs in this pass to change the behaviour of programs we're
-      // formatting, so check that the pretty-printed AST is the same before and after reformatting.
-      String expected = parse(input, /* allowStringFolding= */ true).toString();
-      String actual = parse(result, /* allowStringFolding= */ true).toString();
-      if (!expected.equals(actual)) {
-        throw new FormatterException(
-            String.format(
-                "Something has gone terribly wrong. Please file a bug: "
-                    + "https://github.com/google/google-java-format/issues/new"
-                    + "\n\n=== Actual: ===\n%s\n=== Expected: ===\n%s\n",
-                actual, expected));
-      }
-    }
-
-    return result;
+    return replacements;
   }
 
   /**

--- a/core/src/test/java/com/google/googlejavaformat/java/SnippetFormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/SnippetFormatterTest.java
@@ -39,9 +39,7 @@ public class SnippetFormatterTest {
                 4,
                 false);
     assertThat(replacements)
-        .containsExactly(
-            Replacement.create(Range.closedOpen(1, 2), " "),
-            Replacement.create(Range.closedOpen(3, 3), " "));
+        .containsExactly(Replacement.create(1, 2, " "), Replacement.create(3, 3, " "));
   }
 
   @Test
@@ -56,9 +54,7 @@ public class SnippetFormatterTest {
                 4,
                 false);
     assertThat(replacements)
-        .containsExactly(
-            Replacement.create(Range.closedOpen(5, 6), " "),
-            Replacement.create(Range.closedOpen(7, 7), " "));
+        .containsExactly(Replacement.create(5, 6, " "), Replacement.create(7, 7, " "));
   }
 
   @Test
@@ -72,7 +68,7 @@ public class SnippetFormatterTest {
                 ImmutableList.of(Range.closedOpen(0, input.length())),
                 4,
                 false);
-    assertThat(replacements).containsExactly(Replacement.create(Range.closedOpen(10, 11), ""));
+    assertThat(replacements).containsExactly(Replacement.create(10, 11, ""));
   }
 
   @Test
@@ -86,7 +82,7 @@ public class SnippetFormatterTest {
                 ImmutableList.of(Range.closedOpen(input.indexOf("class"), input.length())),
                 4,
                 false);
-    assertThat(replacements).containsExactly(Replacement.create(Range.closedOpen(22, 23), ""));
+    assertThat(replacements).containsExactly(Replacement.create(22, 23, ""));
   }
 
   @Test
@@ -101,7 +97,6 @@ public class SnippetFormatterTest {
                 4,
                 true);
     assertThat(replacements)
-        .containsExactly(
-            Replacement.create(Range.closedOpen(0, 24), "/** a b */\nclass Test {}\n"));
+        .containsExactly(Replacement.create(0, 24, "/** a b */\nclass Test {}\n"));
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/StringWrapperIntegrationTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/StringWrapperIntegrationTest.java
@@ -378,6 +378,8 @@ public class StringWrapperIntegrationTest {
         .collect(toImmutableList());
   }
 
+  private final Formatter formatter = new Formatter();
+
   private final String input;
   private final String output;
 
@@ -388,24 +390,25 @@ public class StringWrapperIntegrationTest {
 
   @Test
   public void test() throws Exception {
-    assertThat(StringWrapper.wrap(40, new Formatter().formatSource(input))).isEqualTo(output);
+    assertThat(StringWrapper.wrap(40, formatter.formatSource(input), formatter)).isEqualTo(output);
   }
 
   @Test
   public void testCR() throws Exception {
-    assertThat(StringWrapper.wrap(40, new Formatter().formatSource(input.replace("\n", "\r"))))
+    assertThat(StringWrapper.wrap(40, formatter.formatSource(input.replace("\n", "\r")), formatter))
         .isEqualTo(output.replace("\n", "\r"));
   }
 
   @Test
   public void testCRLF() throws Exception {
-    assertThat(StringWrapper.wrap(40, new Formatter().formatSource(input.replace("\n", "\r\n"))))
+    assertThat(
+            StringWrapper.wrap(40, formatter.formatSource(input.replace("\n", "\r\n")), formatter))
         .isEqualTo(output.replace("\n", "\r\n"));
   }
 
   @Test
   public void idempotent() throws Exception {
-    String wrap = StringWrapper.wrap(40, new Formatter().formatSource(input));
-    assertThat(wrap).isEqualTo(new Formatter().formatSource(wrap));
+    String wrap = StringWrapper.wrap(40, formatter.formatSource(input), formatter);
+    assertThat(wrap).isEqualTo(formatter.formatSource(wrap));
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/StringWrapperTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/StringWrapperTest.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.googlejavaformat.java;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/core/src/test/java/com/google/googlejavaformat/java/StringWrapperTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/StringWrapperTest.java
@@ -1,0 +1,44 @@
+package com.google.googlejavaformat.java;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Joiner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** {@link StringWrapper}Test */
+@RunWith(JUnit4.class)
+public class StringWrapperTest {
+  @Test
+  public void testAwkwardLineEndWrapping() throws Exception {
+    String input =
+        lines(
+            "class T {",
+            // This is a wide line, but has to be split in code because of 100-char limit.
+            "  String s = someMethodWithQuiteALongNameThatWillGetUsUpCloseToTheColumnLimit() "
+                + "+ \"foo bar foo bar foo bar\";",
+            "",
+            "  String someMethodWithQuiteALongNameThatWillGetUsUpCloseToTheColumnLimit() {",
+            "    return null;",
+            "  }",
+            "}");
+    String output =
+        lines(
+            "class T {",
+            "  String s =",
+            "      someMethodWithQuiteALongNameThatWillGetUsUpCloseToTheColumnLimit()",
+            "          + \"foo bar foo bar foo bar\";",
+            "",
+            "  String someMethodWithQuiteALongNameThatWillGetUsUpCloseToTheColumnLimit() {",
+            "    return null;",
+            "  }",
+            "}");
+
+    assertThat(StringWrapper.wrap(100, input, new Formatter())).isEqualTo(output);
+  }
+
+  private static String lines(String... line) {
+    return Joiner.on('\n').join(line) + '\n';
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on the PR and we can submit follow-up changes as necessary.

Commits:
=====
<p> google-java-format: construct the Replacement range in the constructor, in order to guarantee it is closedOpen.

Remove the Replacement.create(Range,String) overload, since the bounds were not checked for correctness (open/closed, lower bound >= 0).

fbda4fa4c19601d19a05a74dcfaf232eb0b6f5aa

-------

<p> JavaInputAstVisitor: fix unchecked cast

(Warnings kept cropping up while compiling my StringWrapper changes...)

c75faefca95811a9433a8b943e34621abf19a3d4

-------

<p> Delete obsolete unused import logic

we no longer support removing imports that are used in javadoc.

e8e5978a88eeec80384f082459321420df1ac640

-------

<p> google-java-formatter: reformat portions of the text affected by reflowing

4302caddc0aedbe48ce88837cbdd3aa7ff5d566d

-------

<p> Add missing license headers

dc06c6fbedf5a50023dba254d1d1f2137094f8d1

-------

<p> Switch from oraclejdk9 to openjdk9 in Travis builds, per https://travis-ci.community/t/java-9-build-failing-with-https-certificate-exception/4364/2.

b4f1c7bacab6bcd9ca9a75037e0702a873a60940

-------

<p> Changing oraclejdk8 to openjdk8 in hopes that it will fix our Travis builds.

3406f158564637a8ac77c6b4c7b14c8b0b183078