### PR TITLE
Make JavaOutput.flush() public

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
@@ -178,7 +178,7 @@ public final class JavaOutput extends Output {
   }
 
   /** Flush any incomplete last line, then add the EOF token into our data structures. */
-  void flush() {
+  public void flush() {
     String lastLine = lineBuilder.toString();
     if (!CharMatcher.whitespace().matchesAllOf(lastLine)) {
       mutableLines.add(lastLine);


### PR DESCRIPTION
so it can be accessed by other formatters.