### PR TITLE
MOE Sync 2019-11-06

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/Input.java
+++ b/core/src/main/java/com/google/googlejavaformat/Input.java
@@ -111,6 +111,20 @@ public abstract class Input extends InputOutput {
 
   public abstract String getText();
 
+  /**
+   * Get the number of toks.
+   *
+   * @return the number of toks, including the EOF tok
+   */
+  public abstract int getkN();
+
+  /**
+   * Get the Token by index.
+   *
+   * @param k the token index
+   */
+  public abstract Token getToken(int k);
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("super", super.toString()).toString();

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInput.java
@@ -594,7 +594,8 @@ public final class JavaInput extends Input {
    *
    * @return the number of toks, including the EOF tok
    */
-  int getkN() {
+  @Override
+  public int getkN() {
     return kN;
   }
 
@@ -603,7 +604,8 @@ public final class JavaInput extends Input {
    *
    * @param k the token index
    */
-  Token getToken(int k) {
+  @Override
+  public Token getToken(int k) {
     return kToToken[k];
   }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
@@ -46,7 +46,7 @@ import java.util.Map;
  */
 public final class JavaOutput extends Output {
   private final String lineSeparator;
-  private final JavaInput javaInput; // Used to follow along while emitting the output.
+  private final Input javaInput; // Used to follow along while emitting the output.
   private final CommentsHelper commentsHelper; // Used to re-flow comments.
   private final Map<Integer, BlankLineWanted> blankLines = new HashMap<>(); // Info on blank lines.
   private final RangeSet<Integer> partialFormatRanges = TreeRangeSet.create();
@@ -62,10 +62,10 @@ public final class JavaOutput extends Output {
   /**
    * {@code JavaOutput} constructor.
    *
-   * @param javaInput the {@link JavaInput}, used to match up blank lines in the output
+   * @param javaInput the {@link Input}, used to match up blank lines in the output
    * @param commentsHelper the {@link CommentsHelper}, used to rewrite comments
    */
-  public JavaOutput(String lineSeparator, JavaInput javaInput, CommentsHelper commentsHelper) {
+  public JavaOutput(String lineSeparator, Input javaInput, CommentsHelper commentsHelper) {
     this.lineSeparator = lineSeparator;
     this.javaInput = javaInput;
     this.commentsHelper = commentsHelper;

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaOutput.java
@@ -178,7 +178,7 @@ public final class JavaOutput extends Output {
   }
 
   /** Flush any incomplete last line, then add the EOF token into our data structures. */
-  void flush() {
+  public void flush() {
     String lastLine = lineBuilder.toString();
     if (!CharMatcher.whitespace().matchesAllOf(lastLine)) {
       mutableLines.add(lastLine);

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "0.4.9"
+  id "org.jetbrains.intellij" version "0.4.11"
 }
 
 repositories {
@@ -31,14 +31,13 @@ apply plugin: 'java'
 
 intellij {
   pluginName = "google-java-format"
-  updateSinceUntilBuild = true
-  version = "191.5849.21"
+  version = "193.4932.9-EAP-SNAPSHOT"
 }
 
 patchPluginXml {
   pluginDescription = "Formats source code using the google-java-format tool. This version of " +
                       "the plugin uses version ${googleJavaFormatVersion} of the tool."
-  version = "${googleJavaFormatVersion}.0.2"
+  version = "${googleJavaFormatVersion}.0.3"
   sinceBuild = '173'
   untilBuild = ''
 }

--- a/idea_plugin/resources/META-INF/plugin.xml
+++ b/idea_plugin/resources/META-INF/plugin.xml
@@ -12,6 +12,8 @@
 
   <change-notes><![CDATA[
     <dl>
+      <dt>1.7.0.3</dt>
+      <dd>Fixed the plugin on 2019.3 IDEs.</dd>
       <dt>1.7.0.2</dt>
       <dd>Added support for all IDEs after 2017.3.</dd>
       <dt>1.7.0.1</dt>

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
@@ -122,6 +122,10 @@ class CodeStyleManagerDecorator extends CodeStyleManager
     return delegate.adjustLineIndent(document, offset);
   }
 
+  public void scheduleIndentAdjustment(Document document, int offset) {
+    delegate.scheduleIndentAdjustment(document, offset);
+  }
+
   @Override
   public boolean isLineToBeIndented(PsiFile file, int offset) {
     return delegate.isLineToBeIndented(file, offset);


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update the OSS gjf plugin to work with 2019.3.

Fixes #404

e0fc4b239ee5490a69e009157e875d1580aea3d6

-------

<p> Update the changelog for 1.7.0.3.

b0fb506f63465cecb82bdce9bd0f38309dddd213

-------

<p> Make JavaOutput.flush() public so it can be accessed by other
formatters.

Fixes #411

3a565a1bab73985cc17fb7e954bcbee54cf87ec3

-------

<p> Pull JavaInput.{getkN,getToken} up to Input so `JavaOutput`
can be reused in formatters of other languages.

Fixes #412

8a67ecc19ddfc68919255737340f4be131ba3b85