### PR TITLE
MOE Sync 2019-12-23

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3546,26 +3546,27 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   /**
    * Can a local with a set of modifiers be declared with horizontal annotations? This is currently
-   * true if there is at most one marker annotation, and no others.
+   * true if there is at most one parameterless annotation, and no others.
    *
    * @param modifiers the list of {@link ModifiersTree}s
    * @return whether the local can be declared with horizontal annotations
    */
   private Direction canLocalHaveHorizontalAnnotations(ModifiersTree modifiers) {
-    int markerAnnotations = 0;
+    int parameterlessAnnotations = 0;
     for (AnnotationTree annotation : modifiers.getAnnotations()) {
       if (annotation.getArguments().isEmpty()) {
-        markerAnnotations++;
+        parameterlessAnnotations++;
       }
     }
-    return markerAnnotations <= 1 && markerAnnotations == modifiers.getAnnotations().size()
+    return parameterlessAnnotations <= 1
+            && parameterlessAnnotations == modifiers.getAnnotations().size()
         ? Direction.HORIZONTAL
         : Direction.VERTICAL;
   }
 
   /**
    * Should a field with a set of modifiers be declared with horizontal annotations? This is
-   * currently true if all annotations are marker annotations.
+   * currently true if all annotations are parameterless annotations.
    */
   private Direction fieldAnnotationDirection(ModifiersTree modifiers) {
     for (AnnotationTree annotation : modifiers.getAnnotations()) {


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> annotation/parameterless annotation

Parameterless annotations aren't necessarily marker annotations.
All we can tell about a use of an annotation is that it's parameterless,
and that's how 4.8.5 is specified.

Related: #360

f7f077d5fa8f3132ebd91ad623f1982967473b20