### PR TITLE
Unbreak Maven build on JDK 11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <source>8</source>
           <encoding>UTF-8</encoding>
           <docencoding>UTF-8</docencoding>
           <charset>UTF-8</charset>


### PR DESCRIPTION
This unbreaks `mvn install` on AdoptOpenJDK 11.
Presumably it unbreaks on all JDKs >= 11.
(I only tested this on AdoptOpenJDK 11)

Source: https://bugs.openjdk.java.net/browse/JDK-8212233?attachmentViewMode=list

Motivation: https://github.com/facebookincubator/ktfmt/issues/11