### PR TITLE
MOE Sync 2020-01-06

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -83,6 +83,7 @@
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
+          <source>8</source>
           <encoding>UTF-8</encoding>
           <docencoding>UTF-8</docencoding>
           <charset>UTF-8</charset>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Tell maven-javadoc-plugin to target JDK 8

This unbreaks `mvn install` on AdoptOpenJDK 11.
Presumably it unbreaks on all JDKs >= 11.

Fixes #429

db389b117d00f259b51bac04c5fba785caad8c0c