### PR TITLE
MOE Sync 2020-03-16

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,8 +46,8 @@
 
     <!-- Compile-time dependencies -->
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -89,7 +89,6 @@
           <charset>UTF-8</charset>
           <links>
             <link>https://guava.dev/releases/${guava.version}/api/docs/</link>
-            <link>https://javadoc.io/static/com.google.code.findbugs/jsr305/${jsr305.version}/</link>
             <link>https://docs.oracle.com/javase/8/docs/api/</link>
           </links>
         </configuration>

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -81,7 +81,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.openjdk.javax.lang.model.element.Name;
 import org.openjdk.source.tree.AnnotatedTypeTree;
 import org.openjdk.source.tree.AnnotationTree;

--- a/core/src/main/java/com/google/googlejavaformat/java/filer/FormattingFiler.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/filer/FormattingFiler.java
@@ -18,13 +18,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.googlejavaformat.java.Formatter;
 import java.io.IOException;
-import javax.annotation.Nullable;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A decorating {@link Filer} implementation which formats Java source files with a {@link

--- a/core/src/main/java/com/google/googlejavaformat/java/filer/FormattingJavaFileObject.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/filer/FormattingJavaFileObject.java
@@ -22,11 +22,11 @@ import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 import java.io.IOException;
 import java.io.Writer;
-import javax.annotation.Nullable;
 import javax.annotation.processing.Messager;
 import javax.tools.Diagnostic;
 import javax.tools.ForwardingJavaFileObject;
 import javax.tools.JavaFileObject;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A {@link JavaFileObject} decorator which {@linkplain Formatter formats} source code. */
 final class FormattingJavaFileObject extends ForwardingJavaFileObject<JavaFileObject> {

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
@@ -33,7 +33,7 @@ import com.intellij.psi.codeStyle.Indent;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.ThrowableRunnable;
 import java.util.Collection;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Decorates the {@link CodeStyleManager} abstract class by delegating to a concrete implementation

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.java
@@ -26,12 +26,12 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import java.awt.Insets;
-import javax.annotation.Nullable;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
@@ -22,7 +22,7 @@ import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
-import javax.annotation.Nullable;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 @State(
     name = "GoogleJavaFormatSettings",

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <guava.version>28.1-jre</guava.version>
     <javac.version>9+181-r4173-1</javac.version>
     <truth.version>1.0</truth.version>
-    <jsr305.version>3.0.2</jsr305.version>
+    <checker.version>2.0.0</checker.version>
   </properties>
 
   <dependencyManagement>
@@ -117,9 +117,9 @@
 
       <!-- Compile-time dependencies -->
       <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>${jsr305.version}</version>
+        <groupId>org.checkerframework</groupId>
+        <artifactId>checker-qual</artifactId>
+        <version>${checker.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Migrate from JSR-305 to the Checker Framework annotations

this is tangentially related to Java 11 preparedness.

dac42f8d35341ca952555aebedf349f62a29ba24