### PR TITLE
MOE Sync 2020-03-20

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -32,7 +32,6 @@ import com.google.googlejavaformat.Newlines;
 import com.google.googlejavaformat.Op;
 import com.google.googlejavaformat.OpsBuilder;
 import com.sun.tools.javac.file.JavacFileManager;
-import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
@@ -116,10 +115,6 @@ public final class Formatter {
     DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
     context.put(DiagnosticListener.class, diagnostics);
     Options.instance(context).put("allowStringFolding", "false");
-    // TODO(cushon): this should default to the latest supported source level, remove this after
-    // backing out
-    // https://github.com/google/error-prone-javac/commit/c97f34ddd2308302587ce2de6d0c984836ea5b9f
-    Options.instance(context).put(Option.SOURCE, "9");
     JCCompilationUnit unit;
     JavacFileManager fileManager = new JavacFileManager(context, true, UTF_8);
     try {

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3251,7 +3251,9 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         visitAndBreakModifiers(
             modifiers.get(), annotationsDirection, Optional.of(verticalAnnotationBreak));
       }
-      builder.open(type != null ? plusFour : ZERO);
+      boolean isVar = builder.peekToken().get().equals("var");
+      boolean hasType = type != null || isVar;
+      builder.open(hasType ? plusFour : ZERO);
       {
         builder.open(ZERO);
         {
@@ -3264,13 +3266,15 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
               maybeAddDims(dims);
               builder.close();
               baseDims = totalDims - dims.size();
+            } else if (isVar) {
+              token("var");
             } else {
               scan(type, null);
             }
           }
           builder.close();
 
-          if (type != null) {
+          if (hasType) {
             builder.breakOp(Doc.FillMode.INDEPENDENT, " ", ZERO, Optional.of(typeBreak));
           }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/RemoveUnusedImports.java
@@ -40,7 +40,6 @@ import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.api.JavacTrees;
 import com.sun.tools.javac.file.JavacFileManager;
-import com.sun.tools.javac.main.Option;
 import com.sun.tools.javac.parser.JavacParser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.tree.DCTree;
@@ -186,8 +185,6 @@ public class RemoveUnusedImports {
 
   public static String removeUnusedImports(final String contents) throws FormatterException {
     Context context = new Context();
-    // TODO(cushon): this should default to the latest supported source level, same as in Formatter
-    Options.instance(context).put(Option.SOURCE, "9");
     JCCompilationUnit unit = parse(context, contents);
     if (unit == null) {
       // error handling is done during formatting


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Use the default / latest supported language level

Previously the shaded javac was defaulting to Java 8, which we needed to
override to support Java 9. Now that we're using stock JDK 11 this is
unnecessary.

Also explicitly support `var`, instead of relying on it getting parsed as
an actual type name.

5115c7a6fdc2046c171a44a9c249315b298ab072