### PR TITLE
MOE Sync 2020-03-26

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3192,7 +3192,13 @@ public final class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       if (column >= row.size()) {
         continue;
       }
-      nodeTypes.add(row.get(column).getKind());
+      // Treat UnaryTree expressions as their underlying type for the comparison (so, for example
+      // -ve and +ve numeric literals are considered the same).
+      if (row.get(column) instanceof UnaryTree) {
+        nodeTypes.add(((UnaryTree) row.get(column)).getExpression().getKind());
+      } else {
+        nodeTypes.add(row.get(column).getKind());
+      }
     }
     for (Multiset.Entry<Tree.Kind> nodeType : nodeTypes.entrySet()) {
       if (nodeType.getCount() >= atLeastM) {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/TabularMixedSignInitializer.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/TabularMixedSignInitializer.input
@@ -1,0 +1,17 @@
+public class T {
+  private static final double[] f = {
+    95.0, 75.0, -95.0, 75.0,
+    -95.0, 75.0, +95.0, 75.0
+  };
+
+  private static final int[] g = {
+    x++, y, ++z,
+    x, y, ~z,
+    --x, ++y, z--
+  };
+
+  private static final bool[] h = {
+    a, b, c, d,
+    !e, a, b, c
+  };
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/TabularMixedSignInitializer.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/TabularMixedSignInitializer.output
@@ -1,0 +1,17 @@
+public class T {
+  private static final double[] f = {
+    95.0, 75.0, -95.0, 75.0,
+    -95.0, 75.0, +95.0, 75.0
+  };
+
+  private static final int[] g = {
+    x++, y, ++z,
+    x, y, ~z,
+    --x, ++y, z--
+  };
+
+  private static final bool[] h = {
+    a, b, c, d,
+    !e, a, b, c
+  };
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Preserve tabular arguments for mixed sign numeric lists.

Treats unary minus literals (eg -4.0) as their underlying type when checking if all elements in a tabular list are of the same Tree.Kind.

Fixes #400, #406

0689cf25d1e0a936838e2488d0c2faa895486ca7