### PR TITLE
idea_plugin: Migrate from Components API to Listeners API

### DIFF
--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "0.4.11"
+  id "org.jetbrains.intellij" version "0.4.17"
 }
 
 repositories {

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'java'
 
 intellij {
   pluginName = "google-java-format"
-  version = "193.4932.9-EAP-SNAPSHOT"
+  version = "201.6668.13-EAP-SNAPSHOT"
 }
 
 patchPluginXml {

--- a/idea_plugin/resources/META-INF/plugin.xml
+++ b/idea_plugin/resources/META-INF/plugin.xml
@@ -23,19 +23,12 @@
     </dl>
   ]]></change-notes>
 
-  <project-components>
-    <component>
-      <implementation-class>
-        com.google.googlejavaformat.intellij.GoogleJavaFormatInstaller
-      </implementation-class>
-      <loadForDefaultProject/>
-    </component>
-    <component>
-      <implementation-class>
-        com.google.googlejavaformat.intellij.InitialConfigurationComponent
-      </implementation-class>
-    </component>
-  </project-components>
+  <applicationListeners>
+    <listener class="com.google.googlejavaformat.intellij.InitialConfigurationProjectManagerListener"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <listener class="com.google.googlejavaformat.intellij.GoogleJavaFormatInstaller"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+  </applicationListeners>
 
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.google.googlejavaformat.intellij.GoogleJavaFormatConfigurable"

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatInstaller.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatInstaller.java
@@ -17,32 +17,22 @@
 package com.google.googlejavaformat.intellij;
 
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.application.impl.ApplicationInfoImpl;
-import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.psi.codeStyle.CodeStyleManager;
-import com.intellij.serviceContainer.PlatformComponentManagerImpl;
-import org.picocontainer.MutablePicoContainer;
+import com.intellij.serviceContainer.ComponentManagerImpl;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * A component that replaces the default IntelliJ {@link CodeStyleManager} with one that formats via
+ * A listener that replaces the default IntelliJ {@link CodeStyleManager} with one that formats via
  * google-java-format.
  */
-final class GoogleJavaFormatInstaller implements ProjectComponent {
-
-  private static final String CODE_STYLE_MANAGER_KEY = CodeStyleManager.class.getName();
-
-  private final Project project;
-
-  private GoogleJavaFormatInstaller(Project project) {
-    this.project = project;
-  }
+public class GoogleJavaFormatInstaller implements ProjectManagerListener {
 
   @Override
-  public void projectOpened() {
+  public void projectOpened(@NotNull Project project) {
     installFormatter(project);
   }
 
@@ -57,20 +47,8 @@ final class GoogleJavaFormatInstaller implements ProjectComponent {
   }
 
   private static void setManager(Project project, CodeStyleManager newManager) {
-    if (useNewServicesApi()) {
-      PlatformComponentManagerImpl platformComponentManager =
-          (PlatformComponentManagerImpl) project;
-      IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId("google-java-format"));
-      platformComponentManager.registerServiceInstance(CodeStyleManager.class, newManager, plugin);
-    } else {
-      MutablePicoContainer container = (MutablePicoContainer) project.getPicoContainer();
-      container.unregisterComponent(CODE_STYLE_MANAGER_KEY);
-      container.registerComponentInstance(CODE_STYLE_MANAGER_KEY, newManager);
-    }
-  }
-
-  private static boolean useNewServicesApi() {
-    ApplicationInfo appInfo = ApplicationInfoImpl.getInstance();
-    return appInfo.getBuild().getBaselineVersion() >= 193;
+    ComponentManagerImpl platformComponentManager = (ComponentManagerImpl) project;
+    IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("google-java-format"));
+    platformComponentManager.registerServiceInstance(CodeStyleManager.class, newManager, plugin);
   }
 }

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
@@ -20,32 +20,27 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
-import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManagerListener;
+import org.jetbrains.annotations.NotNull;
 
-final class InitialConfigurationComponent implements ProjectComponent {
+public final class InitialConfigurationProjectManagerListener implements ProjectManagerListener {
 
   private static final String NOTIFICATION_TITLE = "Enable google-java-format";
   private static final NotificationGroup NOTIFICATION_GROUP =
-      new NotificationGroup(NOTIFICATION_TITLE, NotificationDisplayType.STICKY_BALLOON, true);
-
-  private final Project project;
-  private final GoogleJavaFormatSettings settings;
-
-  public InitialConfigurationComponent(Project project, GoogleJavaFormatSettings settings) {
-    this.project = project;
-    this.settings = settings;
-  }
+    new NotificationGroup(NOTIFICATION_TITLE, NotificationDisplayType.STICKY_BALLOON, true);
 
   @Override
-  public void projectOpened() {
+  public void projectOpened(@NotNull Project project) {
+    GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
+
     if (settings.isUninitialized()) {
       settings.setEnabled(false);
-      displayNewUserNotification();
+      displayNewUserNotification(project, settings);
     }
   }
 
-  private void displayNewUserNotification() {
+  private void displayNewUserNotification(@NotNull Project project, GoogleJavaFormatSettings settings) {
     Notification notification =
         new Notification(
             NOTIFICATION_GROUP.getDisplayId(),


### PR DESCRIPTION
I believe that these changes will future-proof the plugin, since the API that's currently used is deprecated. This should also resolve #449.

To be honest, I have no clue about backward compatibility, e.g. what might be the oldest version of IntelliJ able to load the plugin...