### PR TITLE
Fix javadoc syntax

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -2574,7 +2574,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         typeWithDims);
   }
 
-  /** Does not omit the leading '<', which should be associated with the type name. */
+  /** Does not omit the leading {@code "<"}, which should be associated with the type name. */
   protected void typeParametersRest(
       List<? extends TypeParameterTree> typeParameters, Indent plusIndent) {
     builder.open(plusIndent);


### PR DESCRIPTION
Fix javadoc syntax by wrap `<` into an inline code block.

```
[WARNING] ...\google-java-format\core\src\main\java\com\google\googlejavaformat\java\JavaInputAstVisitor.java:2577: warning - invalid usage of tag <
```