### PR TITLE
MOE Sync 2020-04-22

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3273,7 +3273,9 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         visitAndBreakModifiers(
             modifiers.get(), annotationsDirection, Optional.of(verticalAnnotationBreak));
       }
-      boolean isVar = builder.peekToken().get().equals("var");
+      boolean isVar =
+          builder.peekToken().get().equals("var")
+              && (!name.contentEquals("var") || builder.peekToken(1).get().equals("var"));
       boolean hasType = type != null || isVar;
       builder.open(hasType ? plusFour : ZERO);
       {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B154342628.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B154342628.input
@@ -1,0 +1,8 @@
+class B154342628 {
+  void f() {
+    var var = 42;
+    return writtenVariables.stream()
+        .filter(var -> deletedVariableIds.contains(var.getId()))
+        .collect(toImmutableList());
+  }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B154342628.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B154342628.output
@@ -1,0 +1,8 @@
+class B154342628 {
+  void f() {
+    var var = 42;
+    return writtenVariables.stream()
+        .filter(var -> deletedVariableIds.contains(var.getId()))
+        .collect(toImmutableList());
+  }
+}


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Make re-parsing of var more robust

to support uses of `var` as an identifier, with and without a type,
e.g. in `var -> {  ... }` and `int var x = 42`;
and uses of `var

e308b6dc77575d3ca4f5c9f690f90a620135fd47