### PR TITLE
MOE Sync 2020-04-27

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -1332,8 +1332,11 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     return null;
   }
 
-  // TODO(cushon): Use Flags.COMPACT_RECORD_CONSTRUCTOR once if/when we drop support for Java 11
+  // TODO(cushon): Use Flags if/when we drop support for Java 11
+
   protected static final long COMPACT_RECORD_CONSTRUCTOR = 1L << 51;
+
+  protected static final long RECORD = 1L << 61;
 
   @Override
   public Void visitMethod(MethodTree node, Void unused) {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/java14.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/java14.input
@@ -19,6 +19,14 @@ class Java14 {
     }
   }
 
+  record Foo(int id) {}
+
+  record Rcv(int id) {
+    public Rcv(Rcv this, int id) {
+      this.id = id;
+    }
+  }
+
   void g() {
     var block = """
     hello

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/java14.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/java14.output
@@ -19,6 +19,14 @@ class Java14 {
     }
   }
 
+  record Foo(int id) {}
+
+  record Rcv(int id) {
+    public Rcv(Rcv this, int id) {
+      this.id = id;
+    }
+  }
+
   void g() {
     var block = """
     hello

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "0.4.11"
+  id "org.jetbrains.intellij" version "0.4.18"
 }
 
 repositories {
@@ -31,14 +31,14 @@ apply plugin: 'java'
 
 intellij {
   pluginName = "google-java-format"
-  version = "193.4932.9-EAP-SNAPSHOT"
+  version = "2020.1"
 }
 
 patchPluginXml {
   pluginDescription = "Formats source code using the google-java-format tool. This version of " +
                       "the plugin uses version ${googleJavaFormatVersion} of the tool."
-  version = "${googleJavaFormatVersion}.0.3"
-  sinceBuild = '173'
+  version = "${googleJavaFormatVersion}.0.5"
+  sinceBuild = '201'
   untilBuild = ''
 }
 

--- a/idea_plugin/resources/META-INF/plugin.xml
+++ b/idea_plugin/resources/META-INF/plugin.xml
@@ -12,6 +12,10 @@
 
   <change-notes><![CDATA[
     <dl>
+      <dt>1.7.0.5</dt>
+      <dd>Added a version for 2020.1+ IDEs.</dd>
+      <dt>1.7.0.4</dt>
+      <dd>Marked the plugin as being incompatible with 2020.1+ IDEs.</dd>
       <dt>1.7.0.3</dt>
       <dd>Fixed the plugin on 2019.3 IDEs.</dd>
       <dt>1.7.0.2</dt>
@@ -23,19 +27,12 @@
     </dl>
   ]]></change-notes>
 
-  <project-components>
-    <component>
-      <implementation-class>
-        com.google.googlejavaformat.intellij.GoogleJavaFormatInstaller
-      </implementation-class>
-      <loadForDefaultProject/>
-    </component>
-    <component>
-      <implementation-class>
-        com.google.googlejavaformat.intellij.InitialConfigurationComponent
-      </implementation-class>
-    </component>
-  </project-components>
+  <applicationListeners>
+    <listener class="com.google.googlejavaformat.intellij.InitialConfigurationProjectManagerListener"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <listener class="com.google.googlejavaformat.intellij.GoogleJavaFormatInstaller"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+  </applicationListeners>
 
   <extensions defaultExtensionNs="com.intellij">
     <projectConfigurable instance="com.google.googlejavaformat.intellij.GoogleJavaFormatConfigurable"

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatInstaller.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatInstaller.java
@@ -16,33 +16,25 @@
 
 package com.google.googlejavaformat.intellij;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
-import com.intellij.openapi.application.ApplicationInfo;
-import com.intellij.openapi.application.impl.ApplicationInfoImpl;
-import com.intellij.openapi.components.ProjectComponent;
+import com.intellij.ide.plugins.PluginManagerCore;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManagerListener;
 import com.intellij.psi.codeStyle.CodeStyleManager;
-import com.intellij.serviceContainer.PlatformComponentManagerImpl;
-import org.picocontainer.MutablePicoContainer;
+import com.intellij.serviceContainer.ComponentManagerImpl;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * A component that replaces the default IntelliJ {@link CodeStyleManager} with one that formats via
  * google-java-format.
  */
-final class GoogleJavaFormatInstaller implements ProjectComponent {
-
-  private static final String CODE_STYLE_MANAGER_KEY = CodeStyleManager.class.getName();
-
-  private final Project project;
-
-  private GoogleJavaFormatInstaller(Project project) {
-    this.project = project;
-  }
+final class GoogleJavaFormatInstaller implements ProjectManagerListener {
 
   @Override
-  public void projectOpened() {
+  public void projectOpened(@NotNull Project project) {
     installFormatter(project);
   }
 
@@ -57,20 +49,9 @@ final class GoogleJavaFormatInstaller implements ProjectComponent {
   }
 
   private static void setManager(Project project, CodeStyleManager newManager) {
-    if (useNewServicesApi()) {
-      PlatformComponentManagerImpl platformComponentManager =
-          (PlatformComponentManagerImpl) project;
-      IdeaPluginDescriptor plugin = PluginManager.getPlugin(PluginId.getId("google-java-format"));
-      platformComponentManager.registerServiceInstance(CodeStyleManager.class, newManager, plugin);
-    } else {
-      MutablePicoContainer container = (MutablePicoContainer) project.getPicoContainer();
-      container.unregisterComponent(CODE_STYLE_MANAGER_KEY);
-      container.registerComponentInstance(CODE_STYLE_MANAGER_KEY, newManager);
-    }
-  }
-
-  private static boolean useNewServicesApi() {
-    ApplicationInfo appInfo = ApplicationInfoImpl.getInstance();
-    return appInfo.getBuild().getBaselineVersion() >= 193;
+    ComponentManagerImpl platformComponentManager = (ComponentManagerImpl) project;
+    IdeaPluginDescriptor plugin = PluginManagerCore.getPlugin(PluginId.getId("google-java-format"));
+    checkState(plugin != null, "Couldn't locate our own PluginDescriptor.");
+    platformComponentManager.registerServiceInstance(CodeStyleManager.class, newManager, plugin);
   }
 }

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
@@ -20,32 +20,28 @@ import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationType;
-import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManagerListener;
+import org.jetbrains.annotations.NotNull;
 
-final class InitialConfigurationComponent implements ProjectComponent {
+final class InitialConfigurationProjectManagerListener implements ProjectManagerListener {
 
   private static final String NOTIFICATION_TITLE = "Enable google-java-format";
   private static final NotificationGroup NOTIFICATION_GROUP =
       new NotificationGroup(NOTIFICATION_TITLE, NotificationDisplayType.STICKY_BALLOON, true);
 
-  private final Project project;
-  private final GoogleJavaFormatSettings settings;
-
-  public InitialConfigurationComponent(Project project, GoogleJavaFormatSettings settings) {
-    this.project = project;
-    this.settings = settings;
-  }
-
   @Override
-  public void projectOpened() {
+  public void projectOpened(@NotNull Project project) {
+
+    GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
+
     if (settings.isUninitialized()) {
       settings.setEnabled(false);
-      displayNewUserNotification();
+      displayNewUserNotification(project, settings);
     }
   }
 
-  private void displayNewUserNotification() {
+  private void displayNewUserNotification(Project project, GoogleJavaFormatSettings settings) {
     Notification notification =
         new Notification(
             NOTIFICATION_GROUP.getDisplayId(),


### PR DESCRIPTION
This code has been reviewed and submitted internally. Feel free to discuss on
the PR, and we can submit follow-up changes as necessary.

Commits:
=====
<p> Update the open-source google-java-format plugin for 2020.1.

I couldn't find any good way to make this backwards compatible. Oh well.

FYI, It looks like in 2020.1, we can probably actually use the
ExternalFormatProcessor extension point instead of doing all this hacky
nonsense... they added a #format(PsiFile, TextRange) method you can override.
But I'll leave that for later because 2020.1 is out now and people are mad.

a24b04f09b51b2b33f39c357be3eaf3f3017ac63

-------

<p> Fix formatting of records without an explicit constructor

Fixes https://github.com/google/google-java-format/issues/460

a399e821dab2ad6286d5f5ad4ff8299cbc8b41fb