### PR TITLE
Fix Eclipse plugin build

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -157,51 +157,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
-        <executions>
-          <execution>
-            <id>copy-resources</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>../eclipse_plugin/lib</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>target</directory>
-                  <include>${project.artifactId}-${project.version}.jar</include>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.10</version>
-        <executions>
-          <execution>
-            <id>copy-dependencies</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>../eclipse_plugin/lib</outputDirectory>
-              <overWriteReleases>true</overWriteReleases>
-              <overWriteSnapshots>true</overWriteSnapshots>
-              <excludeTransitive>true</excludeTransitive>
-              <excludeArtifactIds>org.eclipse.jdt.core</excludeArtifactIds>
-              <excludeScope>compile</excludeScope>
-              <excludeScope>provided</excludeScope>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>com.google.code.maven-replacer-plugin</groupId>
         <artifactId>replacer</artifactId>
         <version>1.5.3</version>

--- a/eclipse_plugin/META-INF/MANIFEST.MF
+++ b/eclipse_plugin/META-INF/MANIFEST.MF
@@ -2,14 +2,14 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: google-java-format
 Bundle-SymbolicName: google-java-format-eclipse-plugin;singleton:=true
-Bundle-Version: 1.6.0
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: Google
+Bundle-Version: 1.8.0
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.jface,
  org.eclipse.text,
  org.eclipse.ui,
  org.eclipse.equinox.common
 Bundle-ClassPath: .,
- lib/guava-22.0.jar,
- lib/javac-shaded-9+181-r4173-1.jar,
- lib/google-java-format-1.6.jar
+ lib/guava-28.1-jre.jar,
+ lib/google-java-format-1.8.jar

--- a/eclipse_plugin/META-INF/MANIFEST.MF
+++ b/eclipse_plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: google-java-format
 Bundle-SymbolicName: google-java-format-eclipse-plugin;singleton:=true
 Bundle-Vendor: Google
-Bundle-Version: 1.8.0
+Bundle-Version: 1.9.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.jface,
@@ -12,4 +12,4 @@ Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.equinox.common
 Bundle-ClassPath: .,
  lib/guava-28.1-jre.jar,
- lib/google-java-format-1.8.jar
+ lib/google-java-format-1.9.jar

--- a/eclipse_plugin/README.md
+++ b/eclipse_plugin/README.md
@@ -1,4 +1,4 @@
-# google-java-format Eclipse Plugin
+# Google Java Format Eclipse Plugin
 
 ## Enabling
 
@@ -6,21 +6,41 @@ See https://github.com/google/google-java-format#eclipse
 
 ## Development
 
-1) Uncomment `<module>eclipse_plugin</module>` in the parent `pom.xml`
+### Prerequisites
 
-2) Run `mvn install`, which will copy the dependences of the plugin to
-`eclipse_plugin/lib`.
+Make sure that the `build.properties` and `META-INF/MANIFEST.MF` contain all necessary dependencies
+for the build. Furthermore, make sure that the dependencies declared in the `pom.xml` match the
+entries in `build.properties` and `META-INF/MANIFEST.MF`.
 
-2) If you are using Java 9, add
+If the used google java format core version is a 'SNAPSHOT' release, the version for the Eclipse
+plugin in the `pom.xml` must end in '-SNAPSHOT' as well and the bundle version specified in
+`META-INF/MANIFEST.MF` must end in '.qualifier'.
 
-    ```
-    -vm
-    /Library/Java/JavaVirtualMachines/jdk1.8.0_91.jdk/Contents/Home/bin/java
-    ```
+### Building the Plugin
 
-    to `/Applications/Eclipse.app/Contents/Eclipse/eclipse.ini`.
+1) Run `mvn clean package` in the `eclipse_plugin` directory. This will first copy the dependencies
+of the plugin to `eclipse_plugin/lib/` and then triggers the tycho build that uses these
+dependencies (as declared in `build.properties`) for the actual Eclipse plugin build.<br><br>
+If you also want to add the build artifact to the local maven repository, you can use
+`mvn clean install -Dtycho.localArtifacts=ignore` instead. Note, however, that you then must use
+this build command for every build with that specific version number until you clear the build
+artifact (or the
+[p2-local-metadata.properties](https://wiki.eclipse.org/Tycho/Target_Platform#Locally_built_artifacts))
+from your local repository. Otherwise, you might run into issues caused by the build using an
+outdated build artifact created by a previous build instead of re-building the plugin. More
+information on this issue is given
+[in this thread](https://www.eclipse.org/lists/tycho-user/msg00952.html) and
+[this bug tracker entry](https://bugs.eclipse.org/bugs/show_bug.cgi?id=355367).
 
-3) Open the `eclipse_plugin` project in a recent Eclipse SDK build.
+2) You can find the built plugin in
+`eclipse_plugin/target/google-java-format-eclipse-plugin-<version>.jar`
 
-4) From `File > Export` select `Plugin-in Development > Deployable plugin-ins
-and fragments` and follow the wizard to export a plugin jar.
+#### Building against a local (snapshot) release of the core
+
+With the current build setup, the Eclipse plugin build pulls the needed build artifacts of the
+google java format core specified in the property `google-java-format.version` and copies it into
+the `eclipse_plugin/lib/` directory.
+
+If you instead want to build against a local (snapshot) build of the core which is not available in
+a maven repository (local or otherwise), you will have to place the appropriate version into the
+`eclipse_plugin/lib/` directory yourself before the build.

--- a/eclipse_plugin/build.properties
+++ b/eclipse_plugin/build.properties
@@ -4,4 +4,4 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                lib/guava-28.1-jre.jar,\
-               lib/google-java-format-1.8.jar
+               lib/google-java-format-1.9.jar

--- a/eclipse_plugin/build.properties
+++ b/eclipse_plugin/build.properties
@@ -3,6 +3,5 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/javac-shaded-9+181-r4173-1.jar,\
-               lib/guava-22.0.jar,\
-               lib/google-java-format-1.6.jar
+               lib/guava-28.1-jre.jar,\
+               lib/google-java-format-1.8.jar

--- a/eclipse_plugin/plugin.xml
+++ b/eclipse_plugin/plugin.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   Copyright 2020 Google Inc.
 
@@ -14,7 +16,6 @@
   limitations under the License.
 -->
 
-<?xml version="1.0" encoding="UTF-8"?>
 <?eclipse version="3.4"?>
 <plugin>
    <extension point="org.eclipse.jdt.core.javaFormatter">

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -14,27 +14,46 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <groupId>com.google.googlejavaformat</groupId>
-    <artifactId>google-java-format-parent</artifactId>
-    <version>1.6</version>
-  </parent>
 
+  <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-eclipse-plugin</artifactId>
-  <version>1.6.0</version>
   <packaging>eclipse-plugin</packaging>
-  <name>google-java-format Plugin for Eclipse 4.5+</name>
+  <version>1.8.0</version>
+
+  <name>Google Java Format Plugin for Eclipse 4.5+</name>
 
   <description>
-    A Java source code formatter that follows Google Java Style.
+    A Java source code formatter plugin for Eclipse that follows Google Java Style.
   </description>
 
   <properties>
-    <tycho-version>0.26.0</tycho-version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <tycho-version>1.7.0</tycho-version>
+
+    <!-- specific library versions; must match declarations in build.properties and META-INF/MANIFEST.MF -->
+    <google-java-format.version>1.8</google-java-format.version>
+    <guava.version>28.1-jre</guava.version>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.googlejavaformat</groupId>
+      <artifactId>google-java-format</artifactId>
+      <version>${google-java-format.version}</version>
+      <type>jar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <type>jar</type>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>
@@ -44,16 +63,28 @@
     </repository>
   </repositories>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.googlejavaformat</groupId>
-      <artifactId>google-java-format</artifactId>
-      <version>1.6</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <outputDirectory>lib</outputDirectory>
+          <includeScope>runtime</includeScope>
+          <excludeTransitive>true</excludeTransitive>
+          <overWriteSnapshots>true</overWriteSnapshots>
+        </configuration>
+      </plugin>
 
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
@@ -61,7 +92,6 @@
         <version>${tycho-version}</version>
         <extensions>true</extensions>
       </plugin>
-
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
@@ -97,7 +127,15 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
-
 </project>

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-eclipse-plugin</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.8.0</version>
+  <version>1.9.0</version>
 
   <name>Google Java Format Plugin for Eclipse 4.5+</name>
 
@@ -36,7 +36,7 @@
     <tycho-version>1.7.0</tycho-version>
 
     <!-- specific library versions; must match declarations in build.properties and META-INF/MANIFEST.MF -->
-    <google-java-format.version>1.8</google-java-format.version>
+    <google-java-format.version>1.9</google-java-format.version>
     <guava.version>28.1-jre</guava.version>
   </properties>
 


### PR DESCRIPTION
Updates the Eclipse plugin build logic. The logic is now completely separate from the main google java format build. Instead of relying on the build artifacts of the core build, the needed google-java-format and guava build artifacts used for the build are now pulled from maven.

Updates google-java-format version used for the build to '1.9', the build JDK to 11, and removes old dependencies which are no longer used.

Updates tycho version to 1.7.0 in order to build with JDK > 8.

Updates the build guide in the README.