### PR TITLE
Make the formatJavadoc option public.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaFormatterOptions.java
@@ -60,7 +60,7 @@ public class JavaFormatterOptions {
     return style.indentationMultiplier();
   }
 
-  boolean formatJavadoc() {
+  public boolean formatJavadoc() {
     return formatJavadoc;
   }
 
@@ -91,7 +91,7 @@ public class JavaFormatterOptions {
       return this;
     }
 
-    Builder formatJavadoc(boolean formatJavadoc) {
+    public Builder formatJavadoc(boolean formatJavadoc) {
       this.formatJavadoc = formatJavadoc;
       return this;
     }


### PR DESCRIPTION
Right now the `formatJavadoc` option in the `JavaFormatterOptions` isn't tag as either public or private so it gets the default package private scope. This change makes it public so other projects using this as a dependency can change this option.

In regards to tests, I'm not sure how to add the relevant test to validate the scope change but since we don't generally test scope, I assume we can skip them?.