### PR TITLE
Emacs integration: correct signature for executable custom variable predicate.

### DIFF
--- a/core/src/main/scripts/google-java-format.el
+++ b/core/src/main/scripts/google-java-format.el
@@ -46,7 +46,7 @@
 
 A string containing the name or the full path of the executable."
   :group 'google-java-format
-  :type '(file :must-match t :match #'file-executable-p)
+  :type '(file :must-match t :match (lambda (widget file) (file-executable-p file)))
   :risky t)
 
 ;;;###autoload


### PR DESCRIPTION
Per
https://www.gnu.org/software/emacs/manual/html_node/elisp/Type-Keywords.html
the predicate for :match "should be a function that accepts two
arguments...."

Without this fix, when you try to customize google-java-format-executable you
see a very confused Easy Customization buffer and the error message
"widget-apply: Invalid function: #'file-executable-p"