### PR TITLE
Improve version handling for eclipse plugin

### DIFF
--- a/eclipse_plugin/META-INF/MANIFEST.MF
+++ b/eclipse_plugin/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: google-java-format
 Bundle-SymbolicName: google-java-format-eclipse-plugin;singleton:=true
 Bundle-Vendor: Google
-Bundle-Version: 1.9.0
+Bundle-Version: 1.11.0
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.jface,
@@ -11,5 +11,5 @@ Require-Bundle: org.eclipse.jdt.core;bundle-version="3.10.0",
  org.eclipse.ui,
  org.eclipse.equinox.common
 Bundle-ClassPath: .,
- lib/guava-30.1.1-jre.jar,
- lib/google-java-format-1.9.jar
+ lib/guava.jar,
+ lib/google-java-format.jar

--- a/eclipse_plugin/README.md
+++ b/eclipse_plugin/README.md
@@ -8,14 +8,8 @@ See https://github.com/google/google-java-format#eclipse
 
 ### Prerequisites
 
-Make sure that the `build.properties` and `META-INF/MANIFEST.MF` contain all
-necessary dependencies for the build. Furthermore, make sure that the
-dependencies declared in the `pom.xml` match the entries in `build.properties`
-and `META-INF/MANIFEST.MF`.
-
-If the used google java format core version is a 'SNAPSHOT' release, the version
-for the Eclipse plugin in the `pom.xml` must end in '-SNAPSHOT' as well and the
-bundle version specified in `META-INF/MANIFEST.MF` must end in '.qualifier'.
+Before building the plugin, make sure to run `mvn tycho-versions:update-eclipse-metadata` to update
+the bundle version in `META-INF/MANIFEST.MF`.
 
 ### Building the Plugin
 
@@ -39,9 +33,8 @@ information on this issue is given
 #### Building against a local (snapshot) release of the core
 
 With the current build setup, the Eclipse plugin build pulls the needed build
-artifacts of the google java format core specified in the property
-`google-java-format.version` and copies it into the `eclipse_plugin/lib/`
-directory.
+artifacts of the google java format core from the maven repository and copies
+it into the `eclipse_plugin/lib/` directory.
 
 If you instead want to build against a local (snapshot) build of the core which
 is not available in a maven repository (local or otherwise), you will have to

--- a/eclipse_plugin/build.properties
+++ b/eclipse_plugin/build.properties
@@ -3,5 +3,5 @@ output.. = target/classes
 bin.includes = META-INF/,\
                .,\
                plugin.xml,\
-               lib/guava-30.1.1-jre.jar,\
-               lib/google-java-format-1.9.jar
+               lib/guava.jar,\
+               lib/google-java-format.jar

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -22,7 +22,7 @@
   <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-eclipse-plugin</artifactId>
   <packaging>eclipse-plugin</packaging>
-  <version>1.9.0</version>
+  <version>1.11.0</version>
 
   <name>Google Java Format Plugin for Eclipse 4.5+</name>
 
@@ -32,26 +32,14 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
     <tycho-version>1.7.0</tycho-version>
-
-    <!-- specific library versions; must match declarations in build.properties and META-INF/MANIFEST.MF -->
-    <google-java-format.version>1.9</google-java-format.version>
-    <guava.version>30.1.1-jre</guava.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>${google-java-format.version}</version>
-      <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-      <type>jar</type>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 
@@ -81,8 +69,10 @@
         <configuration>
           <outputDirectory>lib</outputDirectory>
           <includeScope>runtime</includeScope>
-          <excludeTransitive>true</excludeTransitive>
+          <stripVersion>true</stripVersion>
+          <overWriteReleases>true</overWriteReleases>
           <overWriteSnapshots>true</overWriteSnapshots>
+          <includeArtifactIds>guava,google-java-format</includeArtifactIds>
         </configuration>
       </plugin>
 
@@ -92,6 +82,16 @@
         <version>${tycho-version}</version>
         <extensions>true</extensions>
       </plugin>
+
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-versions-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <configuration>
+          <newVersion>${project.version}</newVersion>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>


### PR DESCRIPTION
Use same versions for plugin as google-java-format and
strip versions from copied jar to avoid updating build.properties
and MANIFEST.MF.