### PR TITLE
Explicitly state GFJ version to use for Eclipse plugin build

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ and import it into File→Settings→Editor→Code Style.
 
 ### Eclipse
 
-Version 1.6 of the
-[google-java-format Eclipse plugin](https://github.com/google/google-java-format/releases/download/google-java-format-1.6/google-java-format-eclipse-plugin_1.6.0.jar)
-can be downloaded from the releases page. Drop it into the Eclipse
+The current version of the google-java-format Eclipse plugin can be downloaded
+from the [releases page](https://github.com/google/google-java-format/releases)
+(`google-java-format-eclipse-plugin-X.jar`). Drop the jar into the Eclipse
 [drop-ins folder](http://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fmisc%2Fp2_dropins_format.html)
 to activate the plugin.
 

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -33,13 +33,14 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho-version>1.7.0</tycho-version>
+    <google-java-format.version>1.11.0</google-java-format.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.googlejavaformat</groupId>
       <artifactId>google-java-format</artifactId>
-      <version>${project.version}</version>
+      <version>${google-java-format.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Re-adds the GJF version specification to the Eclipse plugin pom.

This decouples the GJF version from the Eclipse plugin version. As a
result, it is possible to increase the Eclipse plugin version without
changing the used GJF core version (e.g. in cases where you want to
increase the patch level of the plugin version when deploying fixes for
the Eclipse plugin).

Additionally, it allows for easier builds with local snapshot versions
of GJF.

Also updates the README to link to the current release. Removes explicit
mention of the Eclipse plugin release 1.6. Links to the release page
instead of a specific JAR file so that the link does not have to be
updated with every release.