### PR TITLE
Don’t break right after a HTML code tag that’s followed by a literal

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocFormatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocFormatter.java
@@ -16,6 +16,7 @@ package com.google.googlejavaformat.java.javadoc;
 
 import static com.google.googlejavaformat.java.javadoc.JavadocLexer.lex;
 import static com.google.googlejavaformat.java.javadoc.Token.Type.BR_TAG;
+import static com.google.googlejavaformat.java.javadoc.Token.Type.LITERAL;
 import static com.google.googlejavaformat.java.javadoc.Token.Type.PARAGRAPH_OPEN_TAG;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
 import static java.util.regex.Pattern.compile;
@@ -23,6 +24,7 @@ import static java.util.regex.Pattern.compile;
 import com.google.common.collect.ImmutableList;
 import com.google.googlejavaformat.java.javadoc.JavadocLexer.LexException;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -55,7 +57,9 @@ public final class JavadocFormatter {
 
   private static String render(List<Token> input, int blockIndent) {
     JavadocWriter output = new JavadocWriter(blockIndent);
-    for (Token token : input) {
+    ListIterator<Token> it = input.listIterator();
+    while (it.hasNext()) {
+      Token token = it.next();
       switch (token.getType()) {
         case BEGIN_JAVADOC:
           output.writeBeginJavadoc();
@@ -95,7 +99,17 @@ public final class JavadocFormatter {
           output.writePreClose(token);
           break;
         case CODE_OPEN_TAG:
-          output.writeCodeOpen(token);
+          if (it.hasNext()) {
+            Token nextToken = it.next();
+            it.previous();
+            if (nextToken.getType() == LITERAL) {
+              output.writeCodeOpenWithBreakBeforeIfAtEndOfLine(token);
+            } else {
+              output.writeCodeOpen(token);
+            }
+          } else {
+            output.writeCodeOpen(token);
+          }
           break;
         case CODE_CLOSE_TAG:
           output.writeCodeClose(token);

--- a/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocWriter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/javadoc/JavadocWriter.java
@@ -204,6 +204,10 @@ final class JavadocWriter {
     requestBlankLine();
   }
 
+  void writeCodeOpenWithBreakBeforeIfAtEndOfLine(Token token) {
+    writeToken(token, true);
+  }
+
   void writeCodeOpen(Token token) {
     writeToken(token);
   }
@@ -288,6 +292,10 @@ final class JavadocWriter {
   }
 
   private void writeToken(Token token) {
+    writeToken(token, false);
+  }
+
+  private void writeToken(Token token, boolean breakBeforeIfAtEndOfLine) {
     if (requestedMoeBeginStripComment != null) {
       requestNewline();
     }
@@ -318,7 +326,9 @@ final class JavadocWriter {
      * line, a newline won't help. Or it might help but only by separating "<p>veryverylongword,"
      * which goes against our style.)
      */
-    if (!atStartOfLine && token.length() + (needWhitespace ? 1 : 0) > remainingOnLine) {
+    if (!atStartOfLine
+        && token.length() + (needWhitespace ? 1 : 0) + (breakBeforeIfAtEndOfLine ? 1 : 0)
+            > remainingOnLine) {
       writeNewline();
     }
     if (!atStartOfLine && needWhitespace) {

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/I84.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/I84.input
@@ -1,0 +1,3 @@
+/**
+ * Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx <code>x</code>
+ */

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/I84.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/I84.output
@@ -1,0 +1,4 @@
+/**
+ * Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ * <code>x</code>
+ */


### PR DESCRIPTION
If a `CODE_OPEN_TAG` token is followed by a `LITERAL` token, break before writing the `CODE_OPEN_TAG` token if writing it will result in us eating up the remainder of the current line.

Partially fixes #84.

I’m not super happy about the `breakBeforeIfAtEndOfLine` name, but that’s the best I could come up with right now.  I also wish there was a cleaner way of peeking at the next token.