### PR TITLE
Implement `ToolProvider` SPI

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/FormatToolProvider.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/FormatToolProvider.java
@@ -1,0 +1,19 @@
+package com.google.googlejavaformat.java;
+
+import java.io.PrintWriter;
+import java.util.spi.ToolProvider;
+
+public class FormatToolProvider implements ToolProvider {
+  public String name() {
+    return "format";
+  }
+
+  public int run(PrintWriter out, PrintWriter err, String... args) {
+    try {
+      return Main.main(out, err, args);
+    } catch (Exception e) {
+      err.print(e.getMessage());
+      return -1; // pass non-zero value back indicating an error has happened
+    }
+  }
+}

--- a/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatToolProvider.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/GoogleJavaFormatToolProvider.java
@@ -3,9 +3,10 @@ package com.google.googlejavaformat.java;
 import java.io.PrintWriter;
 import java.util.spi.ToolProvider;
 
-public class FormatToolProvider implements ToolProvider {
+/** Provide a way to be invoked without necessarily starting a new VM. */
+public class GoogleJavaFormatToolProvider implements ToolProvider {
   public String name() {
-    return "format";
+    return "google-java-format";
   }
 
   public int run(PrintWriter out, PrintWriter err, String... args) {

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -63,20 +63,27 @@ public final class Main {
    * @param args the command-line arguments
    */
   public static void main(String[] args) {
-    int result;
     PrintWriter out = new PrintWriter(new OutputStreamWriter(System.out, UTF_8));
     PrintWriter err = new PrintWriter(new OutputStreamWriter(System.err, UTF_8));
+    int result = main(out, err, args);
+    System.exit(result);
+  }
+
+  /**
+   * Package-private main entry point used this CLI program and the java.util.spi.ToolProvider
+   * implementation in the same package as this Main class.
+   */
+  static int main(PrintWriter out, PrintWriter err, String... args) {
     try {
       Main formatter = new Main(out, err, System.in);
-      result = formatter.format(args);
+      return formatter.format(args);
     } catch (UsageException e) {
       err.print(e.getMessage());
-      result = 0;
+      return 0;
     } finally {
       err.flush();
       out.flush();
     }
-    System.exit(result);
   }
 
   /**

--- a/core/src/main/resources/META-INF/services/java.util.spi.ToolProvider
+++ b/core/src/main/resources/META-INF/services/java.util.spi.ToolProvider
@@ -1,0 +1,1 @@
+com.google.googlejavaformat.java.FormatToolProvider

--- a/core/src/main/resources/META-INF/services/java.util.spi.ToolProvider
+++ b/core/src/main/resources/META-INF/services/java.util.spi.ToolProvider
@@ -1,1 +1,1 @@
-com.google.googlejavaformat.java.FormatToolProvider
+com.google.googlejavaformat.java.GoogleJavaFormatToolProvider

--- a/core/src/test/java/com/google/googlejavaformat/java/GoogleJavaFormatToolProviderTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/GoogleJavaFormatToolProviderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.googlejavaformat.java;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ServiceLoader;
+import java.util.spi.ToolProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link GoogleJavaFormatToolProvider}. */
+@RunWith(JUnit4.class)
+public class GoogleJavaFormatToolProviderTest {
+
+  @Test
+  public void testUsageOutputAfterLoadingViaToolName() {
+    String name = "google-java-format";
+
+    ToolProvider format =
+        ServiceLoader.load(ToolProvider.class).stream()
+            .map(ServiceLoader.Provider::get)
+            .filter(provider -> provider.name().equals(name))
+            .findAny()
+            .orElseThrow(() -> new AssertionError("Tool not found by name: " + name));
+
+    StringWriter out = new StringWriter();
+    StringWriter err = new StringWriter();
+
+    int result = format.run(new PrintWriter(out, true), new PrintWriter(err, true), "--help");
+
+    assertThat(result).isEqualTo(0);
+
+    String usage = err.toString();
+
+    // Check that doc links are included.
+    assertThat(usage).contains("https://github.com/google/google-java-format");
+    assertThat(usage).contains("Usage: google-java-format");
+  }
+}


### PR DESCRIPTION
This PR implements Java 9's `ToolProvider` SPI with `GoogleJavaFormatToolProvider` using `google-java-format` as the name.

`jar --describe-module --file google-java-format-HEAD-SNAPSHOT.jar` yields:
```
No module descriptor found. Derived automatic module.

com.google.googlejavaformat automatic
requires java.base mandated

provides java.util.spi.ToolProvider with com.google.googlejavaformat.java.GoogleJavaFormatToolProvider

contains com.google.googlejavaformat
contains com.google.googlejavaformat.java
contains com.google.googlejavaformat.java.filer
contains com.google.googlejavaformat.java.java14
contains com.google.googlejavaformat.java.javadoc
main-class com.google.googlejavaformat.java.Main
```

Same new `provides` line is emitted for the `google-java-format-HEAD-SNAPSHOT-all-deps.jar` file.

Closes #561