### PR TITLE
Cache local Maven repository via actions/setup-java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,12 @@ jobs:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
         uses: actions/checkout@v2
-      - name: 'Cache local Maven repository'
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: 'Set up JDK ${{ matrix.java }}'
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
+          cache: 'maven'
       - name: 'Install'
         shell: bash
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
@@ -79,18 +73,12 @@ jobs:
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@v2
-      - name: 'Cache local Maven repository'
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
       - name: 'Set up JDK 15'
         uses: actions/setup-java@v2
         with:
           java-version: 15
           distribution: 'zulu'
+          cache: 'maven'
           server-id: sonatype-nexus-snapshots
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD


### PR DESCRIPTION
As of August 30, ["`setup-java` supports caching for both Gradle and Maven projects"](https://github.blog/changelog/2021-08-30-github-actions-setup-java-now-supports-dependency-caching/). This helps to reduce the amount of boilerplate code in the workflow file.

More details can be found in the [corresponding docs](https://github.com/actions/setup-java#caching-packages-dependencies). (And if you wonder what's the used cache key format: https://github.com/actions/setup-java/pull/215/)