### PR TITLE
Remove use of distutils

### DIFF
--- a/scripts/google-java-format-diff.py
+++ b/scripts/google-java-format-diff.py
@@ -33,7 +33,7 @@ import string
 import subprocess
 import io
 import sys
-from distutils.spawn import find_executable
+from shutil import which
 
 def main():
   parser = argparse.ArgumentParser(description=
@@ -105,7 +105,7 @@ def main():
   elif args.google_java_format_jar:
     base_command = ['java', '-jar', args.google_java_format_jar]
   else:
-    binary = find_executable('google-java-format') or '/usr/bin/google-java-format'
+    binary = which('google-java-format') or '/usr/bin/google-java-format'
     base_command = [binary]
 
   # Reformat files containing changes in place.


### PR DESCRIPTION
Distutils will be deprecated in python 3.12, see [PEP 632](https://www.python.org/dev/peps/pep-0632/).

`shutil.which` is the recommended replacement for `distutils.spawn.find_executable`.