### PR TITLE
Fix py3 issues with g-j-f-diff

### DIFF
--- a/scripts/google-java-format-diff.py
+++ b/scripts/google-java-format-diff.py
@@ -134,11 +134,11 @@ def main():
     if not args.i:
       with open(filename) as f:
         code = f.readlines()
-      formatted_code = io.StringIO(stdout).readlines()
+      formatted_code = io.StringIO(stdout.decode('utf-8')).readlines()
       diff = difflib.unified_diff(code, formatted_code,
                                   filename, filename,
                                   '(before formatting)', '(after formatting)')
-      diff_string = string.join(diff, '')
+      diff_string = ''.join(diff)
       if len(diff_string) > 0:
         sys.stdout.write(diff_string)
 


### PR DESCRIPTION
- `StringIO` expectes `Text`, not `bytes`.
- `string.join(a,b)` is replaced with `b.join(a)`