### PR TITLE
Update the IntelliJ plugin to use v1.12.0

### DIFF
--- a/idea_plugin/.gitignore
+++ b/idea_plugin/.gitignore
@@ -1,0 +1,5 @@
+build
+.gradle
+gradle
+gradlew
+gradlew.bat

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-  id "org.jetbrains.intellij" version "1.3.0"
+  id "org.jetbrains.intellij" version "1.3.1"
 }
 
 repositories {
@@ -23,7 +23,7 @@ repositories {
 }
 
 ext {
-  googleJavaFormatVersion = '1.13.0'
+  googleJavaFormatVersion = "1.13.0"
 }
 
 apply plugin: "org.jetbrains.intellij"
@@ -35,7 +35,7 @@ targetCompatibility = JavaVersion.VERSION_11
 intellij {
   pluginName = "google-java-format"
   plugins = ["java"]
-  version = "2020.3"
+  version = "221.3427-EAP-CANDIDATE-SNAPSHOT"
 }
 
 patchPluginXml {

--- a/idea_plugin/build.gradle
+++ b/idea_plugin/build.gradle
@@ -26,20 +26,24 @@ ext {
   googleJavaFormatVersion = '1.13.0'
 }
 
-apply plugin: 'org.jetbrains.intellij'
-apply plugin: 'java'
+apply plugin: "org.jetbrains.intellij"
+apply plugin: "java"
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 intellij {
   pluginName = "google-java-format"
-  version = "IC-213.5744.18-EAP-SNAPSHOT"
+  plugins = ["java"]
+  version = "2020.3"
 }
 
 patchPluginXml {
   pluginDescription = "Formats source code using the google-java-format tool. This version of " +
                       "the plugin uses version ${googleJavaFormatVersion} of the tool."
-  version = "${googleJavaFormatVersion}.0"
-  sinceBuild = '201'
-  untilBuild = ''
+  version.set("${googleJavaFormatVersion}.0")
+  sinceBuild = "203"
+  untilBuild = ""
 }
 
 publishPlugin {
@@ -48,8 +52,8 @@ publishPlugin {
 
 sourceSets {
   main {
-    java.srcDir 'src'
-    resources.srcDir 'resources'
+    java.srcDir "src"
+    resources.srcDir "resources"
   }
 }
 

--- a/idea_plugin/resources/META-INF/plugin.xml
+++ b/idea_plugin/resources/META-INF/plugin.xml
@@ -14,7 +14,8 @@
   limitations under the License.
 -->
 
-<idea-plugin url="https://github.com/google/google-java-format/tree/master/idea_plugin" require-restart="true">
+<idea-plugin url="https://github.com/google/google-java-format/tree/master/idea_plugin"
+  require-restart="true">
   <id>google-java-format</id>
   <name>google-java-format</name>
   <vendor url="https://github.com/google/google-java-format">
@@ -24,7 +25,7 @@
   <!-- Mark it as available on all JetBrains IDEs. It's really only useful in
        IDEA and Android Studio, but there's no way to specify that for some
        reason. It won't crash PyCharm or anything, so whatever. -->
-  <depends>com.intellij.modules.lang</depends>
+  <depends>com.intellij.java</depends>
 
   <change-notes><![CDATA[
     <dl>
@@ -58,17 +59,22 @@
   ]]></change-notes>
 
   <applicationListeners>
-    <listener class="com.google.googlejavaformat.intellij.InitialConfigurationProjectManagerListener"
-              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <listener
+      class="com.google.googlejavaformat.intellij.InitialConfigurationProjectManagerListener"
+      topic="com.intellij.openapi.project.ProjectManagerListener"/>
     <listener class="com.google.googlejavaformat.intellij.GoogleJavaFormatInstaller"
-              topic="com.intellij.openapi.project.ProjectManagerListener"/>
+      topic="com.intellij.openapi.project.ProjectManagerListener"/>
   </applicationListeners>
 
   <extensions defaultExtensionNs="com.intellij">
-    <projectConfigurable instance="com.google.googlejavaformat.intellij.GoogleJavaFormatConfigurable"
-                         id="google-java-format.settings"
-                         displayName="google-java-format Settings"/>
-    <projectService serviceImplementation="com.google.googlejavaformat.intellij.GoogleJavaFormatSettings"/>
+    <projectConfigurable
+      instance="com.google.googlejavaformat.intellij.GoogleJavaFormatConfigurable"
+      id="google-java-format.settings"
+      displayName="google-java-format Settings"/>
+    <projectService
+      serviceImplementation="com.google.googlejavaformat.intellij.GoogleJavaFormatSettings"/>
+    <notificationGroup displayType="STICKY_BALLOON" id="Enable google-java-format"
+      isLogByDefault="true"/>
   </extensions>
 
 </idea-plugin>

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
@@ -91,7 +91,7 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public void reformatText(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
+  public void reformatText(@NotNull PsiFile file, @NotNull Collection<? extends TextRange> ranges)
       throws IncorrectOperationException {
     delegate.reformatText(file, ranges);
   }
@@ -104,7 +104,7 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public void reformatTextWithContext(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
+  public void reformatTextWithContext(@NotNull PsiFile file, @NotNull Collection<? extends TextRange> ranges)
       throws IncorrectOperationException {
     delegate.reformatTextWithContext(file, ranges);
   }

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/CodeStyleManagerDecorator.java
@@ -34,10 +34,11 @@ import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.ThrowableRunnable;
 import java.util.Collection;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Decorates the {@link CodeStyleManager} abstract class by delegating to a concrete implementation
- * instance (likely IJ's default instance).
+ * instance (likely IntelliJ's default instance).
  */
 @SuppressWarnings("deprecation")
 class CodeStyleManagerDecorator extends CodeStyleManager
@@ -54,98 +55,101 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public Project getProject() {
+  public @NotNull Project getProject() {
     return delegate.getProject();
   }
 
   @Override
-  public PsiElement reformat(PsiElement element) throws IncorrectOperationException {
+  public @NotNull PsiElement reformat(@NotNull PsiElement element)
+      throws IncorrectOperationException {
     return delegate.reformat(element);
   }
 
   @Override
-  public PsiElement reformat(PsiElement element, boolean canChangeWhiteSpacesOnly)
+  public @NotNull PsiElement reformat(@NotNull PsiElement element, boolean canChangeWhiteSpacesOnly)
       throws IncorrectOperationException {
     return delegate.reformat(element, canChangeWhiteSpacesOnly);
   }
 
   @Override
-  public PsiElement reformatRange(PsiElement element, int startOffset, int endOffset)
+  public PsiElement reformatRange(@NotNull PsiElement element, int startOffset, int endOffset)
       throws IncorrectOperationException {
     return delegate.reformatRange(element, startOffset, endOffset);
   }
 
   @Override
   public PsiElement reformatRange(
-      PsiElement element, int startOffset, int endOffset, boolean canChangeWhiteSpacesOnly)
+      @NotNull PsiElement element, int startOffset, int endOffset, boolean canChangeWhiteSpacesOnly)
       throws IncorrectOperationException {
     return delegate.reformatRange(element, startOffset, endOffset, canChangeWhiteSpacesOnly);
   }
 
   @Override
-  public void reformatText(PsiFile file, int startOffset, int endOffset)
+  public void reformatText(@NotNull PsiFile file, int startOffset, int endOffset)
       throws IncorrectOperationException {
     delegate.reformatText(file, startOffset, endOffset);
   }
 
   @Override
-  public void reformatText(PsiFile file, Collection<? extends TextRange> ranges)
+  public void reformatText(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
       throws IncorrectOperationException {
     delegate.reformatText(file, ranges);
   }
 
   @Override
-  public void reformatTextWithContext(PsiFile psiFile, ChangedRangesInfo changedRangesInfo)
+  public void reformatTextWithContext(
+      @NotNull PsiFile psiFile, @NotNull ChangedRangesInfo changedRangesInfo)
       throws IncorrectOperationException {
     delegate.reformatTextWithContext(psiFile, changedRangesInfo);
   }
 
   @Override
-  public void reformatTextWithContext(PsiFile file, Collection<? extends TextRange> ranges)
+  public void reformatTextWithContext(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
       throws IncorrectOperationException {
     delegate.reformatTextWithContext(file, ranges);
   }
 
   @Override
-  public void adjustLineIndent(PsiFile file, TextRange rangeToAdjust)
+  public void adjustLineIndent(@NotNull PsiFile file, TextRange rangeToAdjust)
       throws IncorrectOperationException {
     delegate.adjustLineIndent(file, rangeToAdjust);
   }
 
   @Override
-  public int adjustLineIndent(PsiFile file, int offset) throws IncorrectOperationException {
+  public int adjustLineIndent(@NotNull PsiFile file, int offset)
+      throws IncorrectOperationException {
     return delegate.adjustLineIndent(file, offset);
   }
 
   @Override
-  public int adjustLineIndent(Document document, int offset) {
+  public int adjustLineIndent(@NotNull Document document, int offset) {
     return delegate.adjustLineIndent(document, offset);
   }
 
-  public void scheduleIndentAdjustment(Document document, int offset) {
+  public void scheduleIndentAdjustment(@NotNull Document document, int offset) {
     delegate.scheduleIndentAdjustment(document, offset);
   }
 
   @Override
-  public boolean isLineToBeIndented(PsiFile file, int offset) {
+  public boolean isLineToBeIndented(@NotNull PsiFile file, int offset) {
     return delegate.isLineToBeIndented(file, offset);
   }
 
   @Override
   @Nullable
-  public String getLineIndent(PsiFile file, int offset) {
+  public String getLineIndent(@NotNull PsiFile file, int offset) {
     return delegate.getLineIndent(file, offset);
   }
 
   @Override
   @Nullable
-  public String getLineIndent(PsiFile file, int offset, FormattingMode mode) {
+  public String getLineIndent(@NotNull PsiFile file, int offset, FormattingMode mode) {
     return delegate.getLineIndent(file, offset, mode);
   }
 
   @Override
   @Nullable
-  public String getLineIndent(Document document, int offset) {
+  public String getLineIndent(@NotNull Document document, int offset) {
     return delegate.getLineIndent(document, offset);
   }
 
@@ -165,7 +169,7 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public void reformatNewlyAddedElement(ASTNode block, ASTNode addedElement)
+  public void reformatNewlyAddedElement(@NotNull ASTNode block, @NotNull ASTNode addedElement)
       throws IncorrectOperationException {
     delegate.reformatNewlyAddedElement(block, addedElement);
   }
@@ -192,22 +196,23 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public int getSpacing(PsiFile file, int offset) {
+  public int getSpacing(@NotNull PsiFile file, int offset) {
     return delegate.getSpacing(file, offset);
   }
 
   @Override
-  public int getMinLineFeeds(PsiFile file, int offset) {
+  public int getMinLineFeeds(@NotNull PsiFile file, int offset) {
     return delegate.getMinLineFeeds(file, offset);
   }
 
   @Override
-  public void runWithDocCommentFormattingDisabled(PsiFile file, Runnable runnable) {
+  public void runWithDocCommentFormattingDisabled(
+      @NotNull PsiFile file, @NotNull Runnable runnable) {
     delegate.runWithDocCommentFormattingDisabled(file, runnable);
   }
 
   @Override
-  public DocCommentSettings getDocCommentSettings(PsiFile file) {
+  public @NotNull DocCommentSettings getDocCommentSettings(@NotNull PsiFile file) {
     return delegate.getDocCommentSettings(file);
   }
 
@@ -223,7 +228,8 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public int adjustLineIndent(final Document document, final int offset, FormattingMode mode)
+  public int adjustLineIndent(
+      final @NotNull Document document, final int offset, FormattingMode mode)
       throws IncorrectOperationException {
     if (delegate instanceof FormattingModeAwareIndentAdjuster) {
       return ((FormattingModeAwareIndentAdjuster) delegate)
@@ -233,7 +239,7 @@ class CodeStyleManagerDecorator extends CodeStyleManager
   }
 
   @Override
-  public void scheduleReformatWhenSettingsComputed(PsiFile file) {
+  public void scheduleReformatWhenSettingsComputed(@NotNull PsiFile file) {
     delegate.scheduleReformatWhenSettingsComputed(file);
   }
 }

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/FormatterUtil.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/FormatterUtil.java
@@ -50,8 +50,7 @@ final class FormatterUtil {
   }
 
   private static Collection<Range<Integer>> toRanges(Collection<? extends TextRange> textRanges) {
-    return textRanges
-        .stream()
+    return textRanges.stream()
         .map(textRange -> Range.closedOpen(textRange.getStartOffset(), textRange.getEndOffset()))
         .collect(Collectors.toList());
   }

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatCodeStyleManager.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatCodeStyleManager.java
@@ -22,10 +22,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.JavaFormatterOptions;
 import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
-import com.intellij.openapi.fileTypes.StdFileTypes;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * A {@link CodeStyleManager} implementation which formats .java files with google-java-format.
- * Formatting of all other types of files is delegated to IJ's default implementation.
+ * Formatting of all other types of files is delegated to IntelliJ's default implementation.
  */
 class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
 
@@ -53,7 +53,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
   }
 
   @Override
-  public void reformatText(PsiFile file, int startOffset, int endOffset)
+  public void reformatText(@NotNull PsiFile file, int startOffset, int endOffset)
       throws IncorrectOperationException {
     if (overrideFormatterForFile(file)) {
       formatInternal(file, ImmutableList.of(new TextRange(startOffset, endOffset)));
@@ -63,7 +63,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
   }
 
   @Override
-  public void reformatText(PsiFile file, Collection<? extends TextRange> ranges)
+  public void reformatText(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
       throws IncorrectOperationException {
     if (overrideFormatterForFile(file)) {
       formatInternal(file, ranges);
@@ -73,7 +73,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
   }
 
   @Override
-  public void reformatTextWithContext(PsiFile file, ChangedRangesInfo info)
+  public void reformatTextWithContext(@NotNull PsiFile file, @NotNull ChangedRangesInfo info)
       throws IncorrectOperationException {
     List<TextRange> ranges = new ArrayList<>();
     if (info.insertedRanges != null) {
@@ -84,7 +84,8 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
   }
 
   @Override
-  public void reformatTextWithContext(PsiFile file, Collection<? extends TextRange> ranges) {
+  public void reformatTextWithContext(
+      @NotNull PsiFile file, @NotNull Collection<TextRange> ranges) {
     if (overrideFormatterForFile(file)) {
       formatInternal(file, ranges);
     } else {
@@ -94,7 +95,10 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
 
   @Override
   public PsiElement reformatRange(
-      PsiElement element, int startOffset, int endOffset, boolean canChangeWhiteSpacesOnly) {
+      @NotNull PsiElement element,
+      int startOffset,
+      int endOffset,
+      boolean canChangeWhiteSpacesOnly) {
     // Only handle elements that are PsiFile for now -- otherwise we need to search for some
     // element within the file at new locations given the original startOffset and endOffsets
     // to serve as the return value.
@@ -107,9 +111,9 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
     }
   }
 
-  /** Return whether or not this formatter can handle formatting the given file. */
+  /** Return whether this formatter can handle formatting the given file. */
   private boolean overrideFormatterForFile(PsiFile file) {
-    return StdFileTypes.JAVA.equals(file.getFileType())
+    return JavaFileType.INSTANCE.equals(file.getFileType())
         && GoogleJavaFormatSettings.getInstance(getProject()).isEnabled();
   }
 
@@ -137,7 +141,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
    * Format the ranges of the given document.
    *
    * <p>Overriding methods will need to modify the document with the result of the external
-   * formatter (usually using {@link #performReplacements(Document, Map)}.
+   * formatter (usually using {@link #performReplacements(Document, Map)}).
    */
   private void format(Document document, Collection<? extends TextRange> ranges) {
     Style style = GoogleJavaFormatSettings.getInstance(getProject()).getStyle();

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatCodeStyleManager.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatCodeStyleManager.java
@@ -63,7 +63,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
   }
 
   @Override
-  public void reformatText(@NotNull PsiFile file, @NotNull Collection<TextRange> ranges)
+  public void reformatText(@NotNull PsiFile file, @NotNull Collection<? extends TextRange> ranges)
       throws IncorrectOperationException {
     if (overrideFormatterForFile(file)) {
       formatInternal(file, ranges);
@@ -85,7 +85,7 @@ class GoogleJavaFormatCodeStyleManager extends CodeStyleManagerDecorator {
 
   @Override
   public void reformatTextWithContext(
-      @NotNull PsiFile file, @NotNull Collection<TextRange> ranges) {
+      @NotNull PsiFile file, @NotNull Collection<? extends TextRange> ranges) {
     if (overrideFormatterForFile(file)) {
       formatInternal(file, ranges);
     } else {

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.project.Project;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 @State(
     name = "GoogleJavaFormatSettings",
@@ -42,7 +43,7 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
   }
 
   @Override
-  public void loadState(State state) {
+  public void loadState(@NotNull State state) {
     this.state = state;
   }
 
@@ -73,7 +74,7 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
   enum EnabledState {
     UNKNOWN,
     ENABLED,
-    DISABLED;
+    DISABLED
   }
 
   static class State {
@@ -85,7 +86,7 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
     public void setEnabled(@Nullable String enabledStr) {
       if (enabledStr == null) {
         enabled = EnabledState.UNKNOWN;
-      } else if (Boolean.valueOf(enabledStr)) {
+      } else if (Boolean.parseBoolean(enabledStr)) {
         enabled = EnabledState.ENABLED;
       } else {
         enabled = EnabledState.DISABLED;

--- a/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
+++ b/idea_plugin/src/com/google/googlejavaformat/intellij/InitialConfigurationProjectManagerListener.java
@@ -17,8 +17,8 @@
 package com.google.googlejavaformat.intellij;
 
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationDisplayType;
 import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManagerListener;
@@ -28,11 +28,10 @@ final class InitialConfigurationProjectManagerListener implements ProjectManager
 
   private static final String NOTIFICATION_TITLE = "Enable google-java-format";
   private static final NotificationGroup NOTIFICATION_GROUP =
-      new NotificationGroup(NOTIFICATION_TITLE, NotificationDisplayType.STICKY_BALLOON, true);
+      NotificationGroupManager.getInstance().getNotificationGroup(NOTIFICATION_TITLE);
 
   @Override
   public void projectOpened(@NotNull Project project) {
-
     GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
 
     if (settings.isUninitialized()) {


### PR DESCRIPTION
Since the last plugin update was almost half a year ago, I thought it would be prudent to update it and resolve most of the issues regarding updating the plugin.

It took around half an hour once I managed to correctly set up the module due to the gradle plugin version 1.2.1 + intellij version 2020.3 requiring java 11 to develop.

All of the included annotation changes were requested by IntelliJ to add since the overrides added them as well.

The change of `<? extends TextRange>` to `<TextRange>` was to resolve the syntax errors introduced by a change removing the wildcard requirement.

NotificationGroup was deprecated and moved into the plugin xml file as per the SDK docs
The same was required for `StdFileTypes.JAVA` being deprecated with the fix being `JavaFileType.INSTANCE` + changing the depend module to add that fix.

I had to change the project SDK to JDK 11 on my end to have the gradle build work. 

I also tested the plugin with 1.12 and 1.10 on some test files such as from #653 and #654. Would be good to have some double checking though because I've had issues trying to get the test file reformatted in #558 working. Probably because it's locked behind an experimental flag?