### PR TITLE
GraalVM native-image Maven build support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -280,9 +280,9 @@
                 <param>${project.build.directory}/${project.artifactId}-${project.version}-all-deps.jar</param>
               </classpath>
               <buildArgs>
-                <buildArg>-H:IncludeResourceBundles=com.sun.tools.javac.resources.javac</buildArg>
-                <buildArg>--verbose</buildArg>
+                <buildArg>-H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler</buildArg>
                 <buildArg>--no-fallback</buildArg>
+                <buildArg>--static</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -249,5 +249,45 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>native</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <version>0.9.9</version>
+            <extensions>true</extensions>
+            <executions>
+              <execution>
+                <id>build-native</id>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+              <execution>
+                <id>test-native</id>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <phase>test</phase>
+              </execution>
+            </executions>
+            <configuration>
+              <imageName>google-java-format</imageName>
+              <classpath>
+                <param>${project.build.directory}/${project.artifactId}-${project.version}-all-deps.jar</param>
+              </classpath>
+              <buildArgs>
+                <buildArg>-H:IncludeResourceBundles=com.sun.tools.javac.resources.javac</buildArg>
+                <buildArg>--verbose</buildArg>
+                <buildArg>--no-fallback</buildArg>
+              </buildArgs>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -282,7 +282,6 @@
               <buildArgs>
                 <buildArg>-H:IncludeResourceBundles=com.sun.tools.javac.resources.compiler</buildArg>
                 <buildArg>--no-fallback</buildArg>
-                <buildArg>--static</buildArg>
               </buildArgs>
             </configuration>
           </plugin>

--- a/core/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/core/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "com.sun.tools.javac.parser.UnicodeReader",
+    "allDeclaredMethods": true
+  }
+]


### PR DESCRIPTION
Closes #358.

This appears to work as expected. I have a [weird case](https://github.com/oracle/graal/discussions/4254) I'm not really sure how to address (the need to specify -Djava.home during execution), but otherwise, this produces a fully static binary that is very fast and works.

To execute the build, you run the following command:

```
mvn -Pnative -DskipTests package
```