### PR TITLE
Automate releases w/ GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ on:
         required: true
 
 jobs:
-  define-release:
+  build-maven-jars:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Setup Signing Key
         run: |
@@ -20,17 +20,14 @@ jobs:
           
       - name: Checkout
         uses: actions/checkout@2.4.0
-        
+
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           java-version: 17
           distribution: 'zulu'
           cache: 'maven'
-
-      - name: Run Tests
-        run: mvn verify
-
+     
       - name: Bump Version Number
         env:
           NEW_VERSION: ${{ github.events.input.version }}
@@ -38,16 +35,15 @@ jobs:
           mvn versions:set versions:commit -DnewVersion="${NEW_VERSION}"
           git ls-files | grep 'pom.xml$' | xargs git add
           git commit -m "Release google-java-format ${NEW_VERSION}"
-          git tag "v${NEW_VERSION}"
-          git push origin "v${NEW_VERSION}"
-          
-      - name: Create Maven Jars
-        run: mvn clean deploy
+          git push
 
-      - name: Define Release Entry
+      - name: Build Jars
+        run: mvn clean verify gpg:sign -DskipTests=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+
+      - name: Add Jars to Release Entry
         uses: softprops/action-gh-release@v1
         with:
           draft: true
           name: ${{ github.events.input.version }} 
           tag_name: "v${{ github.events.input.version }}"
-        
+          files: core/target/google-java-format-*.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release google-java-format
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "version number for this release."
+        required: true
+
+env:
+  JAVA_HOME: "$JAVA_HOME_17_X64"
+
+jobs:
+  define-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Setup Signing Key
+        run: |
+          cat <(echo -e "${{ secrets.GPG_SIGNING_KEY }}") | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+          
+      - name: Checkout
+        uses: actions/checkout@2.4.0
+        
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: 'maven'
+
+      - name: Run Tests
+        run: mvn verify
+
+      - name: Bump Version Number
+        env:
+          NEW_VERSION: ${{ github.events.input.version }}
+        run: |
+          mvn versions:set versions:commit -DnewVersion="${NEW_VERSION}"
+          git ls-files | grep 'pom.xml$' | xargs git add
+          git commit -m "Release google-java-format ${NEW_VERSION}"
+          git tag "v${NEW_VERSION}"
+          git push origin "v${NEW_VERSION}"
+          
+      - name: Create Maven Jars
+        run: mvn clean deploy
+
+      - name: Define Release Entry
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          name: ${{ github.events.input.version }} 
+          tag_name: "v${{ github.events.input.version }}"
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
         description: "version number for this release."
         required: true
 
-env:
-  JAVA_HOME: "$JAVA_HOME_17_X64"
-
 jobs:
   define-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempting to fully automate the release process here, this first attempt is focused on the initial build infrastructure.
Additional work I wanna do:

- Templatize README.md so we can just find/replace the version numbers easy.
- Actually push the signed jars to sonatype
- Begin developing the graalvm/native image aspects.