### PR TITLE
Return a non-zero exit code upon error

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -79,7 +79,8 @@ public final class Main {
       return formatter.format(args);
     } catch (UsageException e) {
       err.print(e.getMessage());
-      return 1;
+      // We return exit code 2 to differentiate usage issues from code formatting issues.
+      return 2;
     } finally {
       err.flush();
       out.flush();

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -79,7 +79,7 @@ public final class Main {
       return formatter.format(args);
     } catch (UsageException e) {
       err.print(e.getMessage());
-      return 0;
+      return 1;
     } finally {
       err.flush();
       out.flush();


### PR DESCRIPTION
This brings us in line with the Unix standard of returning non-zero for a failed command:
https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html

Also, this will allow any callers (like google-java-format-diff.py) to respond appropriately. 
[A change](http://r.android.com/2257232) needed to be reverted because `google-java-format-diff.py` 
was failing silently, so the author wasn't aware that their change caused a pre-upload hook to stop working.