### PR TITLE
Recognize new JSpecify package name

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -285,6 +285,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     ImmutableSetMultimap.Builder<String, String> result = ImmutableSetMultimap.builder();
     for (String annotation :
         ImmutableList.of(
+            "org.jspecify.annotations.Nullable",
             "org.jspecify.nullness.Nullable",
             "org.checkerframework.checker.nullness.qual.Nullable")) {
       String simpleName = annotation.substring(annotation.lastIndexOf('.') + 1);


### PR DESCRIPTION
So that its `@Nullable` annotation is treated as a type-use annotation and formatted accordingly. See jspecify/jspecify#260.