### PR TITLE
Document Trunk Check integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Implementation`.
 *   [Github Actions](https://github.com/features/actions)
     *   [googlejavaformat-action](https://github.com/axel-op/googlejavaformat-action):
         Automatically format your Java files when you push on github
+*   [Trunk Check](https://trunk.io/products/check), a universal linter & formatter (has a [CLI](https://docs.trunk.io/docs/initialize-trunk-in-a-git-repo), [VSCode extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io), and [GitHub Action](https://github.com/trunk-io/trunk-action))
 
 ### as a library
 


### PR DESCRIPTION
Trunk Check is a universal linter which integrates with a wide variety of linters and formatters, `google-java-format` included.

We're big fans of `google-java-format` and figured that you might find our tool to be interesting enough to include it here.