### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ actions.
 #### IntelliJ JRE Config
 
 The google-java-format plugin uses some internal classes that aren't available
-without extra configuration. To use the plugin, go to `Help→Edit Custom VM
-Options...` and paste in these lines:
+without extra configuration. To use the plugin, find the action `Help→Find Action`. Then search for "Custom VM
+Options" and paste in these lines:
 
 ```
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED


### PR DESCRIPTION
Updated the way to find Custom VM Option for Intellij IDEA Community Edition 2022.3.3

Custom VM Option cannot be searched from the help menu. 

![Screenshot 2023-03-28 at 12 01 41 PM](https://user-images.githubusercontent.com/129101895/228340875-e0840d8f-515c-47e0-8749-876781457439.png)
