### PR TITLE
Add documentation for Trunk Check plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Implementation`.
 *   [Github Actions](https://github.com/features/actions)
     *   [googlejavaformat-action](https://github.com/axel-op/googlejavaformat-action):
         Automatically format your Java files when you push on github
+*   [Trunk Check](https://trunk.io/products/check)
+    *   [google-java-format plugin](https://github.com/trunk-io/plugins/tree/main/linters/google-java-format)
+    *   Install with `trunk check enable google-java-format`
 
 ### as a library
 


### PR DESCRIPTION
Trunk Check has a plugin for `google-java-format` which can be enabled by running:

```
trunk check enable google-java-format
```