### PR TITLE
Adds a possible line break after an arrow in the switch expression.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/java17/Java17InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java17/Java17InputAstVisitor.java
@@ -249,8 +249,9 @@ public class Java17InputAstVisitor extends JavaInputAstVisitor {
         builder.space();
         token("-");
         token(">");
-        builder.space();
         if (node.getBody().getKind() == Tree.Kind.BLOCK) {
+          builder.open(ZERO);
+          builder.space();
           // Explicit call with {@link CollapseEmptyOrNot.YES} to handle empty case blocks.
           visitBlock(
               (BlockTree) node.getBody(),
@@ -258,8 +259,11 @@ public class Java17InputAstVisitor extends JavaInputAstVisitor {
               AllowLeadingBlankLine.NO,
               AllowTrailingBlankLine.NO);
         } else {
+          builder.open(plusTwo);
+          builder.breakOp(" ");
           scan(node.getBody(), null);
         }
+        builder.close();
         builder.guessToken(";");
         break;
       default:

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/ExpressionSwitch.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/ExpressionSwitch.input
@@ -38,4 +38,12 @@ class ExpressionSwitch {
       case CASE_A, CASE_B -> {}
     };
   }
+
+  String breakAfterArrows(int i) {
+    return switch (i) {
+      case CASE_A -> shortMethod("shortExpression");
+      case CASE_B -> meeeeeeeeeeeeeeeeeeeeeeeeeeeeediumMethod("meeeeeeeeeeeeeeeeeeeeeeeeeeeeediumMethod");
+      case CASE_C -> loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooMethod("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongExpression");
+    };
+  }
 }

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/ExpressionSwitch.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/ExpressionSwitch.output
@@ -50,4 +50,15 @@ class ExpressionSwitch {
       case CASE_A, CASE_B -> {}
     };
   }
+
+  String breakAfterArrows(int i) {
+    return switch (i) {
+      case CASE_A -> shortMethod("shortExpression");
+      case CASE_B ->
+        meeeeeeeeeeeeeeeeeeeeeeeeeeeeediumMethod("meeeeeeeeeeeeeeeeeeeeeeeeeeeeediumMethod");
+      case CASE_C ->
+        loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooMethod(
+            "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongExpression");
+    };
+  }
 }


### PR DESCRIPTION
Previously the formatter allowed no line break after the arrow. I added in the line break in a similar way to how lambdas are formatted: a line break after the case list and the arrow when it doesn't fit in one line.

Fixes #880.