### PR TITLE
Add support for guard clauses in Java 21 switch expressions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -226,7 +226,7 @@
     <profile>
       <id>jdk11</id>
       <activation>
-        <jdk>(,17)</jdk>
+        <jdk>[11,17)</jdk>
       </activation>
       <build>
         <plugins>
@@ -236,6 +236,7 @@
             <configuration>
               <excludes>
                 <exclude>**/Java17InputAstVisitor.java</exclude>
+                <exclude>**/Java21InputAstVisitor.java</exclude>
               </excludes>
             </configuration>
           </plugin>
@@ -243,6 +244,32 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
               <excludePackageNames>com.google.googlejavaformat.java.java17</excludePackageNames>
+              <excludePackageNames>com.google.googlejavaformat.java.java21</excludePackageNames>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk17</id>
+      <activation>
+        <jdk>[17,21)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>**/Java21InputAstVisitor.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <configuration>
+              <excludePackageNames>com.google.googlejavaformat.java.java21</excludePackageNames>
             </configuration>
           </plugin>
         </plugins>

--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -151,7 +151,17 @@ public final class Formatter {
     OpsBuilder builder = new OpsBuilder(javaInput, javaOutput);
     // Output the compilation unit.
     JavaInputAstVisitor visitor;
-    if (Runtime.version().feature() >= 17) {
+    if (Runtime.version().feature() >= 21) {
+      try {
+        visitor =
+            Class.forName("com.google.googlejavaformat.java.java21.Java21InputAstVisitor")
+                .asSubclass(JavaInputAstVisitor.class)
+                .getConstructor(OpsBuilder.class, int.class)
+                .newInstance(builder, options.indentationMultiplier());
+      } catch (ReflectiveOperationException e) {
+        throw new LinkageError(e.getMessage(), e);
+      }
+    } else if (Runtime.version().feature() >= 17) {
       try {
         visitor =
             Class.forName("com.google.googlejavaformat.java.java17.Java17InputAstVisitor")

--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -152,25 +152,13 @@ public final class Formatter {
     // Output the compilation unit.
     JavaInputAstVisitor visitor;
     if (Runtime.version().feature() >= 21) {
-      try {
-        visitor =
-            Class.forName("com.google.googlejavaformat.java.java21.Java21InputAstVisitor")
-                .asSubclass(JavaInputAstVisitor.class)
-                .getConstructor(OpsBuilder.class, int.class)
-                .newInstance(builder, options.indentationMultiplier());
-      } catch (ReflectiveOperationException e) {
-        throw new LinkageError(e.getMessage(), e);
-      }
+      visitor =
+          createVisitor(
+              "com.google.googlejavaformat.java.java21.Java21InputAstVisitor", builder, options);
     } else if (Runtime.version().feature() >= 17) {
-      try {
-        visitor =
-            Class.forName("com.google.googlejavaformat.java.java17.Java17InputAstVisitor")
-                .asSubclass(JavaInputAstVisitor.class)
-                .getConstructor(OpsBuilder.class, int.class)
-                .newInstance(builder, options.indentationMultiplier());
-      } catch (ReflectiveOperationException e) {
-        throw new LinkageError(e.getMessage(), e);
-      }
+      visitor =
+          createVisitor(
+              "com.google.googlejavaformat.java.java17.Java17InputAstVisitor", builder, options);
     } else {
       visitor = new JavaInputAstVisitor(builder, options.indentationMultiplier());
     }
@@ -181,6 +169,18 @@ public final class Formatter {
     doc.computeBreaks(javaOutput.getCommentsHelper(), MAX_LINE_LENGTH, new Doc.State(+0, 0));
     doc.write(javaOutput);
     javaOutput.flush();
+  }
+
+  private static JavaInputAstVisitor createVisitor(
+      final String className, final OpsBuilder builder, final JavaFormatterOptions options) {
+    try {
+      return Class.forName(className)
+          .asSubclass(JavaInputAstVisitor.class)
+          .getConstructor(OpsBuilder.class, int.class)
+          .newInstance(builder, options.indentationMultiplier());
+    } catch (ReflectiveOperationException e) {
+      throw new LinkageError(e.getMessage(), e);
+    }
   }
 
   static boolean errorDiagnostic(Diagnostic<?> input) {

--- a/core/src/main/java/com/google/googlejavaformat/java/java17/Java17InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java17/Java17InputAstVisitor.java
@@ -22,20 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.googlejavaformat.OpsBuilder;
 import com.google.googlejavaformat.OpsBuilder.BlankLineWanted;
 import com.google.googlejavaformat.java.JavaInputAstVisitor;
-import com.sun.source.tree.AnnotationTree;
-import com.sun.source.tree.BindingPatternTree;
-import com.sun.source.tree.BlockTree;
-import com.sun.source.tree.CaseLabelTree;
-import com.sun.source.tree.CaseTree;
-import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.CompilationUnitTree;
-import com.sun.source.tree.InstanceOfTree;
-import com.sun.source.tree.ModifiersTree;
-import com.sun.source.tree.ModuleTree;
-import com.sun.source.tree.SwitchExpressionTree;
-import com.sun.source.tree.Tree;
-import com.sun.source.tree.VariableTree;
-import com.sun.source.tree.YieldTree;
+import com.sun.source.tree.*;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
@@ -238,6 +225,15 @@ public class Java17InputAstVisitor extends JavaInputAstVisitor {
       }
       builder.close();
     }
+
+    final ExpressionTree guard = getGuard(node);
+    if (guard != null) {
+      builder.space();
+      token("when");
+      builder.space();
+      scan(guard, null);
+    }
+
     switch (node.getCaseKind()) {
       case STATEMENT:
         token(":");
@@ -265,6 +261,10 @@ public class Java17InputAstVisitor extends JavaInputAstVisitor {
       default:
         throw new AssertionError(node.getCaseKind());
     }
+    return null;
+  }
+
+  protected ExpressionTree getGuard(final CaseTree node) {
     return null;
   }
 }

--- a/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
@@ -1,0 +1,76 @@
+package com.google.googlejavaformat.java.java21;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+import com.google.googlejavaformat.OpsBuilder;
+import com.google.googlejavaformat.java.java17.Java17InputAstVisitor;
+import com.sun.source.tree.*;
+import java.util.List;
+
+public class Java21InputAstVisitor extends Java17InputAstVisitor {
+
+  public Java21InputAstVisitor(OpsBuilder builder, int indentMultiplier) {
+    super(builder, indentMultiplier);
+  }
+
+  @Override
+  public Void visitCase(CaseTree node, Void unused) {
+    sync(node);
+    markForPartialFormat();
+    builder.forcedBreak();
+    List<? extends CaseLabelTree> labels = node.getLabels();
+    boolean isDefault =
+        labels.size() == 1 && getOnlyElement(labels).getKind().name().equals("DEFAULT_CASE_LABEL");
+    if (isDefault) {
+      token("default", plusTwo);
+    } else {
+      token("case", plusTwo);
+      builder.open(labels.size() > 1 ? plusFour : ZERO);
+      builder.space();
+      boolean first = true;
+      for (Tree expression : labels) {
+        if (!first) {
+          token(",");
+          builder.breakOp(" ");
+        }
+        scan(expression, null);
+        first = false;
+      }
+      builder.close();
+    }
+    if (node.getGuard() != null) {
+      builder.space();
+      token("when");
+      builder.space();
+      scan(node.getGuard(), null);
+    }
+    switch (node.getCaseKind()) {
+      case STATEMENT:
+        token(":");
+        builder.open(plusTwo);
+        visitStatements(node.getStatements());
+        builder.close();
+        break;
+      case RULE:
+        builder.space();
+        token("-");
+        token(">");
+        builder.space();
+        if (node.getBody().getKind() == Tree.Kind.BLOCK) {
+          // Explicit call with {@link CollapseEmptyOrNot.YES} to handle empty case blocks.
+          visitBlock(
+              (BlockTree) node.getBody(),
+              CollapseEmptyOrNot.YES,
+              AllowLeadingBlankLine.NO,
+              AllowTrailingBlankLine.NO);
+        } else {
+          scan(node.getBody(), null);
+        }
+        builder.guessToken(";");
+        break;
+      default:
+        throw new AssertionError(node.getCaseKind());
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
@@ -1,11 +1,9 @@
 package com.google.googlejavaformat.java.java21;
 
-import static com.google.common.collect.Iterables.getOnlyElement;
-
 import com.google.googlejavaformat.OpsBuilder;
 import com.google.googlejavaformat.java.java17.Java17InputAstVisitor;
-import com.sun.source.tree.*;
-import java.util.List;
+import com.sun.source.tree.CaseTree;
+import com.sun.source.tree.ExpressionTree;
 
 public class Java21InputAstVisitor extends Java17InputAstVisitor {
 
@@ -14,63 +12,7 @@ public class Java21InputAstVisitor extends Java17InputAstVisitor {
   }
 
   @Override
-  public Void visitCase(CaseTree node, Void unused) {
-    sync(node);
-    markForPartialFormat();
-    builder.forcedBreak();
-    List<? extends CaseLabelTree> labels = node.getLabels();
-    boolean isDefault =
-        labels.size() == 1 && getOnlyElement(labels).getKind().name().equals("DEFAULT_CASE_LABEL");
-    if (isDefault) {
-      token("default", plusTwo);
-    } else {
-      token("case", plusTwo);
-      builder.open(labels.size() > 1 ? plusFour : ZERO);
-      builder.space();
-      boolean first = true;
-      for (Tree expression : labels) {
-        if (!first) {
-          token(",");
-          builder.breakOp(" ");
-        }
-        scan(expression, null);
-        first = false;
-      }
-      builder.close();
-    }
-    if (node.getGuard() != null) {
-      builder.space();
-      token("when");
-      builder.space();
-      scan(node.getGuard(), null);
-    }
-    switch (node.getCaseKind()) {
-      case STATEMENT:
-        token(":");
-        builder.open(plusTwo);
-        visitStatements(node.getStatements());
-        builder.close();
-        break;
-      case RULE:
-        builder.space();
-        token("-");
-        token(">");
-        builder.space();
-        if (node.getBody().getKind() == Tree.Kind.BLOCK) {
-          // Explicit call with {@link CollapseEmptyOrNot.YES} to handle empty case blocks.
-          visitBlock(
-              (BlockTree) node.getBody(),
-              CollapseEmptyOrNot.YES,
-              AllowLeadingBlankLine.NO,
-              AllowTrailingBlankLine.NO);
-        } else {
-          scan(node.getBody(), null);
-        }
-        builder.guessToken(";");
-        break;
-      default:
-        throw new AssertionError(node.getCaseKind());
-    }
-    return null;
+  protected ExpressionTree getGuard(final CaseTree node) {
+    return node.getGuard();
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterIntegrationTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterIntegrationTest.java
@@ -52,6 +52,7 @@ public class FormatterIntegrationTest {
           .putAll(15, "I603")
           .putAll(16, "I588")
           .putAll(17, "I683", "I684", "I696")
+          .putAll(21, "SwitchGuardClause")
           .build();
 
   @Parameters(name = "{index}: {0}")

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/SwitchGuardClause.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/SwitchGuardClause.input
@@ -1,0 +1,9 @@
+class SwitchGuardClause {
+  boolean test(Object x) {
+    return switch (x) {
+      case String s when s.length() < 5 -> true;
+      case Integer i -> false;
+      default -> true;
+    };
+  }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/SwitchGuardClause.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/SwitchGuardClause.output
@@ -1,0 +1,9 @@
+class SwitchGuardClause {
+  boolean test(Object x) {
+    return switch (x) {
+      case String s when s.length() < 5 -> true;
+      case Integer i -> false;
+      default -> true;
+    };
+  }
+}


### PR DESCRIPTION
This PR adds support for `switch` statements where a `case` has a guard clause.

See Issue #983 