### PR TITLE
Bump Guava to 32.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <guava.version>32.1.1-jre</guava.version>
+    <guava.version>32.1.3-jre</guava.version>
     <truth.version>1.1.3</truth.version>
     <checker.version>3.21.2</checker.version>
     <errorprone.version>2.16</errorprone.version>


### PR DESCRIPTION
There is an issue about resolving transitive dependencies in Guava breaks GJF 1.18.1 integration in [Spotless](https://github.com/diffplug/spotless), it has been fixed in Guava 32.1.3, it would be nice to follow this update.

See:
- https://github.com/google/guava/issues/6657.
- https://github.com/google/guava/releases/tag/v32.1.3.