### PR TITLE
Add support for Java21 string template

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
@@ -23,6 +23,8 @@ import com.sun.source.tree.DefaultCaseLabelTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.PatternCaseLabelTree;
 import com.sun.source.tree.PatternTree;
+import com.sun.source.tree.StringTemplateTree;
+import java.util.Iterator;
 import javax.lang.model.element.Name;
 
 /**
@@ -85,5 +87,39 @@ public class Java21InputAstVisitor extends Java17InputAstVisitor {
     } else {
       visit(name);
     }
+  }
+
+  @Override
+  public Void visitStringTemplate(StringTemplateTree node, Void unused) {
+
+    scan(node.getProcessor(), null);
+
+    token(".");
+
+    Iterator<? extends ExpressionTree> exprIt = node.getExpressions().iterator();
+
+    Iterator<String> fragIt = node.getFragments().iterator();
+
+    var firstFrag = fragIt.next();
+
+    token("\"" + firstFrag);
+    while (fragIt.hasNext()) {
+      if (exprIt.hasNext()) {
+        ExpressionTree expr = exprIt.next();
+        token("\\");
+        token("{");
+        scan(expr, null);
+        token("}");
+      }
+
+      String frag = fragIt.next();
+      if (!fragIt.hasNext()) {
+        token(frag + "\"");
+      } else {
+        token(frag);
+      }
+    }
+
+    return null;
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterIntegrationTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterIntegrationTest.java
@@ -59,7 +59,8 @@ public class FormatterIntegrationTest {
               "SwitchDouble",
               "SwitchUnderscore",
               "I880",
-              "Unnamed")
+              "Unnamed",
+              "StringTemplate")
           .build();
 
   @Parameters(name = "{index}: {0}")

--- a/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/FormatterTest.java
@@ -492,4 +492,24 @@ public final class FormatterTest {
                 + "  }\n"
                 + "}\n");
   }
+
+  @Test
+  public void stringTemplateTests() throws Exception {
+    assertThat(
+            new Formatter()
+                .formatSource(
+                    "public class Foo {\n"
+                        + "    String test(){\n"
+                        + "        var simple = STR.\"mytemplate1XXXX \\{exampleXXXX.foo()}yyy\";\n"
+                        + "        var nested = STR.\"template \\{example.  foo()+ STR.\"templateInner\\{  example}\"}xxx }\";\n"
+                        + "    }\n"
+                        + "}\n"))
+        .isEqualTo(
+            "public class Foo {\n"
+                + "  String test() {\n"
+                + "    var simple = STR.\"mytemplate1XXXX \\{exampleXXXX.foo()}yyy\";\n"
+                + "    var nested = STR.\"template \\{example.foo() + STR.\"templateInner\\{example}\"}xxx }\";\n"
+                + "  }\n"
+                + "}\n");
+  }
 }

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/StringTemplate.input
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/StringTemplate.input
@@ -1,0 +1,10 @@
+public class StringTemplates {
+    void test(){
+        var m = STR."template \{example}xxx";
+        var nested = STR."template \{example.foo()+ STR."templateInner\{example}"}xxx }";
+        var nestNested = STR."template \{example0.
+                    foo() +
+                    STR."templateInner\{example1.test(STR."\{example2
+                        }")}"}xxx }";
+    }
+}

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/StringTemplate.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/StringTemplate.output
@@ -1,0 +1,9 @@
+public class StringTemplates {
+  void test() {
+    var m = STR."template \{example}xxx";
+    var nested = STR."template \{example.foo() + STR."templateInner\{example}"}xxx }";
+    var nestNested =
+        STR."template \{example0.foo()
+            + STR."templateInner\{example1.test(STR."\{example2}")}"}xxx }";
+  }
+}


### PR DESCRIPTION
86390d0d569d5847d00c3938ec60ad444a3c39e7: Support for string templates and corresponding tests. But won't work, because output tokens of `com.sun.tools.javac.parser.Scanner` are not sorted by their position, and then cause the verification [here](https://github.com/google/google-java-format/blob/4c1aeffc8b0ea3d4e18ffe21162b835f2c51cc3d/core/src/main/java/com/google/googlejavaformat/OpsBuilder.java#L328) failed. 
86390d0d569d5847d00c3938ec60ad444a3c39e7: Read all tokens from Scanner, and sort them if jdk version >= 21.

Some links may be useful:
How jdk parse string template from tokens: https://github.com/openjdk/jdk/blob/3d9d353edb64dd364925481d7b7c8822beeaa117/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java#L695-L746
How tokens of string templates are builded: https://github.com/openjdk/jdk/blob/3d9d353edb64dd364925481d7b7c8822beeaa117/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java#L342-L420