### PR TITLE
Upgrade jdk used by release action to 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.5.0
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'zulu'
           cache: 'maven'
           server-id: sonatype-nexus-staging


### PR DESCRIPTION
Hi, I'm trying to use the newly released version 1.19.0 from the command-line, but it gives me the following error:
```
error: com.google.googlejavaformat.java.java21.Java21InputAstVisitor
java.lang.LinkageError: com.google.googlejavaformat.java.java21.Java21InputAstVisitor
        at com.google.googlejavaformat.java.Formatter.createVisitor(Formatter.java:182)
        at com.google.googlejavaformat.java.Formatter.format(Formatter.java:156)
        at com.google.googlejavaformat.java.Formatter.getFormatReplacements(Formatter.java:283)
        at com.google.googlejavaformat.java.Formatter.formatSource(Formatter.java:257)
        at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:75)
        at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:29)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.ClassNotFoundException: com.google.googlejavaformat.java.java21.Java21InputAstVisitor
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:421)
        at java.base/java.lang.Class.forName(Class.java:412)
        at com.google.googlejavaformat.java.Formatter.createVisitor(Formatter.java:177)
        ... 11 more
```

After doing some tests I think the problem is that the release action is using a jdk 17. This doesn't activate the maven profile jdk17 introduced in this PR https://github.com/google/google-java-format/pull/988 and so java 21 specific classes aren't included in the build process. This simple upgrade should fix the problem.