### PR TITLE
chore: bump checkout/setup-java to v4 (use nodejs20 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
       - name: 'Check out repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Set up JDK ${{ matrix.java }} from jdk.java.net'
         if: ${{ matrix.java == 'EA' }}
         uses: oracle-actions/setup-java@v1
@@ -61,7 +61,7 @@ jobs:
           cache: 'maven'
       - name: 'Set up JDK ${{ matrix.java }}'
         if: ${{ matrix.java != 'EA' }}
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
@@ -80,9 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Check out repository'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Set up JDK 17'
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:         
+    steps:
       - name: Checkout
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: 'zulu'
@@ -27,7 +27,7 @@ jobs:
           server-password: CI_DEPLOY_PASSWORD
           gpg-private-key: ${{ secrets.GPG_SIGNING_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
-     
+
       - name: Bump Version Number
         run: |
           mvn --no-transfer-progress versions:set versions:commit -DnewVersion="${{ github.event.inputs.version }}"
@@ -40,7 +40,7 @@ jobs:
           git tag "v${{ github.event.inputs.version }}"
           echo "TARGET_COMMITISH=$(git rev-parse HEAD)" >> $GITHUB_ENV
           git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/google/google-java-format.git
-          
+
       - name: Deploy to Sonatype staging
         env:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
@@ -56,12 +56,12 @@ jobs:
       - name: Push tag
         run: |
           git push origin "v${{ github.event.inputs.version }}"
-          
+
       - name: Add Jars to Release Entry
         uses: softprops/action-gh-release@v0.1.14
         with:
           draft: true
-          name: ${{ github.event.input.version }} 
+          name: ${{ github.event.input.version }}
           tag_name: "v${{ github.event.inputs.version }}"
           target_commitish: ${{ env.TARGET_COMMITISH }}
           files: |


### PR DESCRIPTION
- bump to latest v4 (which uses nodejs 20 runtime)


cc @cushon