### PR TITLE
chore: fix `SyntaxWarning: invalid escape sequence +` for py3.12

### DIFF
--- a/scripts/google-java-format-diff.py
+++ b/scripts/google-java-format-diff.py
@@ -75,7 +75,7 @@ def main():
   lines_by_file = {}
 
   for line in sys.stdin:
-    match = re.search('^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
+    match = re.search(r'^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
     if match:
       filename = match.group(2)
     if filename == None:
@@ -88,7 +88,7 @@ def main():
       if not re.match('^%s$' % args.iregex, filename, re.IGNORECASE):
         continue
 
-    match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
+    match = re.search(r'^@@.*\+(\d+)(,(\d+))?', line)
     if match:
       start_line = int(match.group(1))
       line_count = 1


### PR DESCRIPTION
```
/opt/homebrew/Cellar/google-java-format/1.19.0/bin/google-java-format-diff:78: SyntaxWarning: invalid escape sequence '\+'
  match = re.search('^\+\+\+\ (.*?/){%s}(\S*)' % args.p, line)
/opt/homebrew/Cellar/google-java-format/1.19.0/bin/google-java-format-diff:91: SyntaxWarning: invalid escape sequence '\+'
  match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
```

relates to https://github.com/Homebrew/homebrew-core/pull/157669

cc @cushon