### PR TITLE
docs: Add link to a VSC Extension to README (fixes #488)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Using the formatter
 
-### from the command-line
+### From the command-line
 
 [Download the formatter](https://github.com/google/google-java-format/releases)
 and run it with:
@@ -78,6 +78,8 @@ Implementation`.
 
 ### Third-party integrations
 
+*   Visual Studio Code
+    *   [google-java-format-for-vs-code](https://marketplace.visualstudio.com/items?itemName=JoseVSeb.google-java-format-for-vs-code)
 *   Gradle plugins
     *   [spotless](https://github.com/diffplug/spotless/tree/main/plugin-gradle#google-java-format)
     *   [sherter/google-java-format-gradle-plugin](https://github.com/sherter/google-java-format-gradle-plugin)


### PR DESCRIPTION
There are a bunch of these; I've had a a bit of a closer look at them the other day, and this one appears to be the most up-to-date, actively maintained, and contrary to the the other more popular by stars older ones seems easy to use because it doesn't require anything to be externally pre-installed but just download from this project's GitHub releases; that's why I'm proposing adding this one.

This fixes #488.

@cushon LGTY?