### PR TITLE
Remove un-used GitHub Action Parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           website: jdk.java.net
           release: ${{ matrix.java }}
-          cache: 'maven'
       - name: 'Set up JDK ${{ matrix.java }}'
         if: ${{ matrix.java != 'EA' }}
         uses: actions/setup-java@v4


### PR DESCRIPTION
The https://github.com/oracle-actions/setup-java/tree/v1/?tab=readme-ov-file#input-overview does not have a "cache" parameter (like https://github.com/actions/setup-java/tree/v4/?tab=readme-ov-file#usage does).

@cushon 