### PR TITLE
Mechanically reformat GitHub Actions YAML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   test:
@@ -28,9 +28,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        java: [ 21, 17, 11 ]
-        experimental: [ false ]
+        os: [ubuntu-latest]
+        java: [21, 17, 11]
+        experimental: [false]
         include:
           # Only test on macos and windows with a single recent JDK to avoid a
           # combinatorial explosion of test configurations.
@@ -50,46 +50,46 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
-      - name: 'Check out repository'
+      - name: "Check out repository"
         uses: actions/checkout@v4
-      - name: 'Set up JDK ${{ matrix.java }} from jdk.java.net'
+      - name: "Set up JDK ${{ matrix.java }} from jdk.java.net"
         if: ${{ matrix.java == 'EA' }}
         uses: oracle-actions/setup-java@v1
         with:
           website: jdk.java.net
           release: ${{ matrix.java }}
-      - name: 'Set up JDK ${{ matrix.java }}'
+      - name: "Set up JDK ${{ matrix.java }}"
         if: ${{ matrix.java != 'EA' }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'zulu'
-          cache: 'maven'
-      - name: 'Install'
+          distribution: "zulu"
+          cache: "maven"
+      - name: "Install"
         shell: bash
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-      - name: 'Test'
+      - name: "Test"
         shell: bash
         run: mvn test -B
 
   publish_snapshot:
-    name: 'Publish snapshot'
+    name: "Publish snapshot"
     needs: test
     if: github.event_name == 'push' && github.repository == 'google/google-java-format' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - name: 'Check out repository'
+      - name: "Check out repository"
         uses: actions/checkout@v4
-      - name: 'Set up JDK 17'
+      - name: "Set up JDK 17"
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'zulu'
-          cache: 'maven'
+          distribution: "zulu"
+          cache: "maven"
           server-id: sonatype-nexus-snapshots
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD
-      - name: 'Publish'
+      - name: "Publish"
         env:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'zulu'
-          cache: 'maven'
+          distribution: "zulu"
+          cache: "maven"
           server-id: sonatype-nexus-staging
           server-username: CI_DEPLOY_USERNAME
           server-password: CI_DEPLOY_PASSWORD
@@ -46,12 +46,10 @@ jobs:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run:
-          mvn --no-transfer-progress -pl '!eclipse_plugin' -P sonatype-oss-release clean deploy -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: mvn --no-transfer-progress -pl '!eclipse_plugin' -P sonatype-oss-release clean deploy -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
 
       - name: Build Eclipse plugin
-        run:
-          mvn --no-transfer-progress -pl 'eclipse_plugin' verify gpg:sign -DskipTests=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: mvn --no-transfer-progress -pl 'eclipse_plugin' verify gpg:sign -DskipTests=true -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
 
       - name: Push tag
         run: |


### PR DESCRIPTION
https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions proposes this format as the "canonical" one.

Adopting this makes it easier to contribute to this project by using that VSC Extension as an editor.

This change is purely mechanical and contains no other "semantic" differences.