### PR TITLE
Build MacOS native binary on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           - os: ubuntu-latest
             java: GraalVM
             experimental: false
+          - os: macos-latest
+            java: GraalVM
+            experimental: false
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:


### PR DESCRIPTION
Follow-up to #1048 to see if if so happens to "just work" on MacOS... it just might? Let's try and see!

PS: I'll tackle Windows separately, because that won't (because of the bash shell test script).

@cushon 