### PR TITLE
Optimze CI to not re-build Eclipse Plugin etc. on GraalVM Native Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,11 @@ jobs:
           native-image-job-reports: "true"
           cache: "maven"
       - name: "Install"
+        if: ${{ matrix.java != 'GraalVM' }}
         shell: bash
         run: mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
       - name: "Test"
+        if: ${{ matrix.java != 'GraalVM' }}
         shell: bash
         run: mvn test -B
       - name: "Native"


### PR DESCRIPTION
@cushon would this make sense?

Re-building the Eclipse plugins and re-running the tests on GraalVM instead of OpenJDK isn't all that interesting - is it?

Just to make it build slightly faster on CI - and save some 10^-♾️ MW energy for the 🪐  planet!