### PR TITLE
Generate native-image binaries for google-java-format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
-      SUFFIX: ${{fromJson('{"ubuntu-latest":"linux-x86_64", "macos-latest":"darwin-arm64", "windows-latest":"windows_x86-64"}')[matrix.os]}}
+      SUFFIX: ${{fromJson('{"ubuntu-latest":"linux-x86-64", "macos-latest":"darwin-arm64", "windows-latest":"windows-x86-64"}')[matrix.os]}}
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
@@ -103,9 +103,9 @@ jobs:
       - name: "Native"
         run: mvn -Pnative -DskipTests package -pl core -am
       - name: "Move outputs"
-        run: cp core/target/google-java-format google-java-format-${{ env.SUFFIX }}
+        run: cp core/target/google-java-format google-java-format_${{ env.SUFFIX }}
       - name: "Upload native-image"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "v${{ github.event.inputs.version }}" "google-java-format-${{ env.SUFFIX }}"
+        run: gh release upload "v${{ github.event.inputs.version }}" "google-java-format_${{ env.SUFFIX }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      SUFFIX: ${{fromJson('{"ubuntu-latest":"linux-x86_64", "macos-latest":"darwin-arm64", "windows-latest":"windows_x86-64"}')[matrix.os]}}
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4
@@ -101,9 +103,9 @@ jobs:
       - name: "Native"
         run: mvn -Pnative -DskipTests package -pl core -am
       - name: "Move outputs"
-        run: cp core/target/google-java-format google-java-format-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
+        run: cp core/target/google-java-format google-java-format-${{ env.SUFFIX }}
       - name: "Upload native-image"
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
-        run: gh release upload "v${{ github.event.inputs.version }}" "google-java-format-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}"
+        run: gh release upload "v${{ github.event.inputs.version }}" "google-java-format-${{ env.SUFFIX }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     needs: build-maven-jars
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: "Check out repository"
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,3 +79,31 @@ jobs:
           files: |
             core/target/google-java-format*
             eclipse_plugin/target/google-java-format-eclipse-plugin-*.jar
+
+  build-native-image:
+    name: "Build GraalVM native-image on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    needs: build-maven-jars
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: "Check out repository"
+        uses: actions/checkout@v4
+      - name: "Set up GraalVM"
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: "21"
+          distribution: "graalvm-community"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          native-image-job-reports: "true"
+          cache: "maven"
+      - name: "Native"
+        run: mvn -Pnative -DskipTests package -pl core -am
+      - name: "Move outputs"
+        run: cp core/target/google-java-format google-java-format-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
+      - name: "Upload native-image"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: gh release upload "v${{ github.event.inputs.version }}" "google-java-format-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}"


### PR DESCRIPTION
And include them in release artifacts.

I tested this on my fork of the repo, and have a demo here: https://github.com/cushon/google-java-format/releases

When downloading the artifacts from the releases page they don't have the executable bit set, and my Mac blocks them because they aren't signed. That can be worked around with the following, but isn't ideal:

```
chmod a+rx google-java-format-darwin
sudo xattr -r -d com.apple.quarantine google-java-format-darwin
```

Progress towards #868, builds on @vorburger's work in #1048.