### PR TITLE
Add option to use default Java import optimizerlly

### DIFF
--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.form
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.google.googlejavaformat.intellij.GoogleJavaFormatConfigurable">
-  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="panel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -18,12 +18,12 @@
       </component>
       <vspacer id="19e83">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="c93e1" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text value="Code style"/>
@@ -31,9 +31,17 @@
       </component>
       <component id="31761" class="javax.swing.JComboBox" binding="styleComboBox" custom-create="true">
         <constraints>
-          <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties/>
+      </component>
+      <component id="22ecd" class="javax.swing.JCheckBox" binding="optimizeImports">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Optimize imports with google-java-format"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatConfigurable.java
@@ -40,6 +40,7 @@ class GoogleJavaFormatConfigurable extends BaseConfigurable implements Searchabl
   private final Project project;
   private JPanel panel;
   private JCheckBox enable;
+  private JCheckBox optimizeImports;
   private JComboBox styleComboBox;
 
   public GoogleJavaFormatConfigurable(Project project) {
@@ -80,6 +81,7 @@ class GoogleJavaFormatConfigurable extends BaseConfigurable implements Searchabl
   public void apply() throws ConfigurationException {
     GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
     settings.setEnabled(enable.isSelected() ? EnabledState.ENABLED : getDisabledState());
+    settings.setOptimizeImports(optimizeImports.isSelected());
     settings.setStyle(((UiFormatterStyle) styleComboBox.getSelectedItem()).convert());
   }
 
@@ -94,6 +96,7 @@ class GoogleJavaFormatConfigurable extends BaseConfigurable implements Searchabl
   public void reset() {
     GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
     enable.setSelected(settings.isEnabled());
+    optimizeImports.setSelected(settings.shouldOptimizeImports());
     styleComboBox.setSelectedItem(UiFormatterStyle.convert(settings.getStyle()));
   }
 
@@ -101,6 +104,7 @@ class GoogleJavaFormatConfigurable extends BaseConfigurable implements Searchabl
   public boolean isModified() {
     GoogleJavaFormatSettings settings = GoogleJavaFormatSettings.getInstance(project);
     return enable.isSelected() != settings.isEnabled()
+        || optimizeImports.isSelected() != settings.shouldOptimizeImports()
         || !styleComboBox.getSelectedItem().equals(UiFormatterStyle.convert(settings.getStyle()));
   }
 

--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingService.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingService.java
@@ -27,6 +27,7 @@ import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.ide.highlighter.JavaFileType;
 import com.intellij.lang.ImportOptimizer;
+import com.intellij.lang.java.JavaImportOptimizer;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiFile;
@@ -40,6 +41,9 @@ public class GoogleJavaFormatFormattingService extends AsyncDocumentFormattingSe
 
   public static final ImmutableSet<ImportOptimizer> IMPORT_OPTIMIZERS =
       ImmutableSet.of(new GoogleJavaFormatImportOptimizer());
+
+  private static final ImmutableSet<ImportOptimizer> DEFAULT_OPTIMIZERS =
+      ImmutableSet.of(new JavaImportOptimizer());
 
   @Override
   protected FormattingTask createFormattingTask(AsyncFormattingRequest request) {
@@ -85,7 +89,11 @@ public class GoogleJavaFormatFormattingService extends AsyncDocumentFormattingSe
 
   @Override
   public @NotNull Set<ImportOptimizer> getImportOptimizers(@NotNull PsiFile file) {
-    return IMPORT_OPTIMIZERS;
+    if (GoogleJavaFormatSettings.getInstance(file.getProject()).shouldOptimizeImports()) {
+      return IMPORT_OPTIMIZERS;
+    } else {
+      return DEFAULT_OPTIMIZERS;
+    }
   }
 
   private static final class GoogleJavaFormatFormattingTask implements FormattingTask {

--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatImportOptimizer.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatImportOptimizer.java
@@ -34,8 +34,11 @@ public class GoogleJavaFormatImportOptimizer implements ImportOptimizer {
 
   @Override
   public boolean supports(@NotNull PsiFile file) {
+    GoogleJavaFormatSettings projectSettings =
+        GoogleJavaFormatSettings.getInstance(file.getProject());
     return JavaFileType.INSTANCE.equals(file.getFileType())
-        && GoogleJavaFormatSettings.getInstance(file.getProject()).isEnabled();
+        && projectSettings.isEnabled()
+        && projectSettings.shouldOptimizeImports();
   }
 
   @Override

--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
@@ -79,6 +79,14 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
     state.style = style;
   }
 
+  boolean shouldOptimizeImports() {
+    return state.optimizeImports;
+  }
+
+  void setOptimizeImports(boolean optimizeImports) {
+    state.optimizeImports = optimizeImports;
+  }
+
   enum EnabledState {
     UNKNOWN,
     ENABLED,
@@ -89,6 +97,7 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
 
     private EnabledState enabled = EnabledState.UNKNOWN;
     public JavaFormatterOptions.Style style = JavaFormatterOptions.Style.GOOGLE;
+    boolean optimizeImports = true;
 
     // enabled used to be a boolean so we use bean property methods for backwards compatibility
     public void setEnabled(@Nullable String enabledStr) {

--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatSettings.java
@@ -97,7 +97,7 @@ class GoogleJavaFormatSettings implements PersistentStateComponent<GoogleJavaFor
 
     private EnabledState enabled = EnabledState.UNKNOWN;
     public JavaFormatterOptions.Style style = JavaFormatterOptions.Style.GOOGLE;
-    boolean optimizeImports = true;
+    public boolean optimizeImports = true;
 
     // enabled used to be a boolean so we use bean property methods for backwards compatibility
     public void setEnabled(@Nullable String enabledStr) {


### PR DESCRIPTION
With v1.16.0, the Intellij plugin started automatically reformatting imports with no option to disable that. Before v1.16.0, it was possible to use custom import rules via Intellij settings, but these are now overridden by `google-java-format`.

See for example issue #986. This means that for code bases that were using `google-java-format <1.16.0` and custom import rules, it is impossible to update `google-java-format`.

This pull request adds a checkbox to the Intellij plugin's settings (default on) that, when off, will fall back to Intellij's default import optimizer, enabling such projects to use current versions of `google-java-format` with their custom import rules.