### PR TITLE
Rename `google-java-format-diff.py` to `google_java_format_diff.py` for **Module Import** Compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The following Apache 2.0 license applies to all code in this package except
-google-java-format-diff.py.
+google_java_format_diff.py.
 
                                  Apache License
                            Version 2.0, January 2004
@@ -205,7 +205,7 @@ google-java-format-diff.py.
 
 ------------------------------------------------------------------------------
 
-The following NCSA license applies only to google-java-format-diff.py.
+The following NCSA license applies only to google_java_format_diff.py.
 
 ==============================================================================
 LLVM Release License

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ offsets (`--offset`), passing through to standard-out (default) or altered
 in-place (`--replace`).
 
 To reformat changed lines in a specific patch, use
-[`google-java-format-diff.py`](https://github.com/google/google-java-format/blob/master/scripts/google-java-format-diff.py).
+[`google_java_format_diff.py`](https://github.com/google/google-java-format/blob/master/scripts/google_java_format_diff.py).
 
 ***Note:*** *There is no configurability as to the formatter's algorithm for
 formatting. This is a deliberate design decision to unify our code formatting on

--- a/scripts/google_java_format_diff.py
+++ b/scripts/google_java_format_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# ===- google-java-format-diff.py - google-java-format Diff Reformatter -----===#
+# ===- google_java_format_diff.py - google-java-format Diff Reformatter -----===#
 #
 #                     The LLVM Compiler Infrastructure
 #
@@ -17,12 +17,12 @@ This script reads input from a unified diff and reformats all the changed
 lines. This is useful to reformat all the lines touched by a specific patch.
 Example usage for git/svn users:
 
-  git diff -U0 HEAD^ | google-java-format-diff.py -p1 -i
-  svn diff --diff-cmd=diff -x-U0 | google-java-format-diff.py -i
+  git diff -U0 HEAD^ | google_java_format_diff.py -p1 -i
+  svn diff --diff-cmd=diff -x-U0 | google_java_format_diff.py -i
 
 For perforce users:
 
-  P4DIFF="git --no-pager diff --no-index" p4 diff | ./google-java-format-diff.py -i -p7
+  P4DIFF="git --no-pager diff --no-index" p4 diff | ./google_java_format_diff.py -i -p7
 
 """
 


### PR DESCRIPTION
This pull request renames the file `google-java-format-diff.py` to `google_java_format_diff.py` and updates all occurrences in the codebase and documentation to reflect this change. The primary motivation for this change is to enable the script to be imported as a Python module, which is not possible with hyphens in the filename.

## Changes Made:
1. Renamed google-java-format-diff.py to google_java_format_diff.py.
2. Updated all occurrences of google-java-format-diff.py in the code, README, and LICENSE to google_java_format_diff.py.

## Benefits:
1. Enables importing google_java_format_diff.py as a module, facilitating its use in other Python scripts and improving modularity.
2. Enhances the script's compatibility with Python standards for module names.

Please review the changes and let me know if any further modifications are needed. Thank you!