### PR TITLE
Fix #1132 Load services outside of constructors and class initializers

### DIFF
--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/InitialConfigurationStartupActivity.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/InitialConfigurationStartupActivity.java
@@ -27,8 +27,6 @@ import org.jetbrains.annotations.NotNull;
 final class InitialConfigurationStartupActivity implements StartupActivity.Background {
 
   private static final String NOTIFICATION_TITLE = "Enable google-java-format";
-  private static final NotificationGroup NOTIFICATION_GROUP =
-      NotificationGroupManager.getInstance().getNotificationGroup(NOTIFICATION_TITLE);
 
   @Override
   public void runActivity(@NotNull Project project) {
@@ -43,9 +41,11 @@ final class InitialConfigurationStartupActivity implements StartupActivity.Backg
   }
 
   private void displayNewUserNotification(Project project, GoogleJavaFormatSettings settings) {
+    NotificationGroupManager groupManager = NotificationGroupManager.getInstance();
+    NotificationGroup group = groupManager.getNotificationGroup(NOTIFICATION_TITLE);
     Notification notification =
         new Notification(
-            NOTIFICATION_GROUP.getDisplayId(),
+            group.getDisplayId(),
             NOTIFICATION_TITLE,
             "The google-java-format plugin is disabled by default. "
                 + "<a href=\"enable\">Enable for this project</a>.",


### PR DESCRIPTION
Fixes the error on startup by loading the service when needed and not when the class is initializing.  IntelliJ docs on this, https://plugins.jetbrains.com/docs/intellij/plugin-services.html#retrieving-a-service.

Tested locally with IntelliJ versions 2021.3 and 2024.2.

#1134 has bug #1132 tagged, but I don't think it does anything to resolve the issue in it's current state. (I do agree that getting on the newer IntelliJ tooling is beneficial though, it offers inspections that catches issues like this.)

Fixes #1132.