### PR TITLE
Add required jvmArgs to runIde for local development testing

### DIFF
--- a/idea_plugin/build.gradle.kts
+++ b/idea_plugin/build.gradle.kts
@@ -49,6 +49,17 @@ tasks {
     token.set(jetbrainsPluginRepoToken)
   }
 
+  runIde.configure {
+    jvmArgs(
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+      "--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    )
+  }
+
   withType<Test>().configureEach {
     jvmArgs(
       "--add-exports", "jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",


### PR DESCRIPTION
When running locally you aren't able to customize the VM options.  This adds the arguments to the `runIde` task, so that the plugin can be tested locally.