### PR TITLE
Fix text block indentation when the text block has no prefix

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
@@ -197,12 +197,10 @@ public final class StringWrapper {
         ImmutableList<String> initialLines = text.lines().collect(toImmutableList());
         String stripped = stripIndent(initialLines.stream().skip(1).collect(joining(separator)));
         ImmutableList<String> lines = stripped.lines().collect(toImmutableList());
-        int deindent =
-            initialLines.get(1).stripTrailing().length() - lines.get(0).stripTrailing().length();
 
         int startColumn = lineMap.getColumnNumber(startPosition);
         String prefix =
-            (deindent == 0 || lines.stream().anyMatch(x -> x.length() + startColumn > columnLimit))
+            (lines.stream().anyMatch(x -> x.length() + startColumn > columnLimit))
                 ? ""
                 : " ".repeat(startColumn - 1);
 

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/RSLs.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/RSLs.output
@@ -48,9 +48,9 @@ ipsum
 """;
   String k =
       """
-lorem
-ipsum
-""";
+      lorem
+      ipsum
+      """;
 
   {
     f(


### PR DESCRIPTION
The simplest example is this:
```
public class A {
  public void foo() {
  String a = """
lorem
ipsum
""";

  String b = """
 lorem
 ipsum
 """;
 }
}
```

Both text blocks should be aligned after the formatter pass but ```a``` isn't:
```
public class A {
  public void foo() {
    String a =
        """
lorem
ipsum
""";

    String b =
        """
        lorem
        ipsum
        """;
  }
}
```

I think the StringWrapper used to apply some more logic to actually "deindent" text block strings but that logic isn't needed and is in fact wrong - I added a comment in the patch.