### PR TITLE
Publish Linux arm64 GraalVM native-image binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,10 @@ jobs:
         # Use "oldest" available ubuntu-* instead of -latest,
         # see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories;
         # due to https://github.com/google/google-java-format/issues/1072.
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-22.04-arm, macos-latest, windows-latest]
     env:
         # NB: Must keep the keys in this inline JSON below in line with the os: above!
-      SUFFIX: ${{fromJson('{"ubuntu-20.04":"linux-x86-64", "macos-latest":"darwin-arm64", "windows-latest":"windows-x86-64"}')[matrix.os]}}
+      SUFFIX: ${{fromJson('{"ubuntu-20.04":"linux-x86-64", "ubuntu-22.04-arm":"linux-arm64", "macos-latest":"darwin-arm64", "windows-latest":"windows-x86-64"}')[matrix.os]}}
       EXTENSION: ${{ matrix.os == 'windows-latest' && '.exe' || '' }}
     steps:
       - name: "Check out repository"


### PR DESCRIPTION
This PR adds [`ubuntu-22.04-arm`](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) to the build-native-image matrix to publish GraalVM native-image binary for Linux arm64.

I tested it on a Ubuntu 22.04.5 LTS container. I am not sure how to test it with the `graalvm/setup-graalvm@v1` action.

```
$ uname -a      
Linux halil-sener-arm 5.15.0-1073-aws #79~20.04.1-Ubuntu SMP Thu Nov 14 02:41:33 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux
$ core/target/google-java-format --help

Usage: google-java-format [options] file(s)
...
```

Note that I had to install two packages (`sudo apt-get install libc6-dev zlib1g-dev`) to build the image.


This PR partially addresses https://github.com/google/google-java-format/issues/1115.