### PR TITLE
docs: Clarify impact of java version used on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ and run it with:
 java -jar /path/to/google-java-format-${GJF_VERSION?}-all-deps.jar <options> [files...]
 ```
 
+Note that it uses the `jdk.compiler` module to parse the Java source code. The `java` binary
+version used must therefore be from a JDK (not JRE) that's at least as big as the files being formatted.
+An alternative is to use the available GraalVM based native binaries instead.
+
 The formatter can act on whole files, on limited lines (`--lines`), on specific
 offsets (`--offset`), passing through to standard-out (default) or altered
 in-place (`--replace`).


### PR DESCRIPTION
It at first confused the hell out of me why clearly the exact SAME version of google-java-format worked great locally but failed with errors (due to my use of record matching pattern syntax) on a GitHub Action - until I've noticed that it still ran under Java 17 - and that this matters to google-java-format (my naive initial assumption was that only the google-java-format version itself was relevant).