### PR TITLE
Preserve markdown-like comment lines

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaCommentsHelper.java
@@ -55,6 +55,13 @@ public final class JavaCommentsHelper implements CommentsHelper {
         lines.add(CharMatcher.whitespace().trimTrailingFrom(it.next()));
       }
     }
+
+    // Crude but works. Don't touch markdown-like line comments, even if they're
+    // somewhere in the code (and are not markdown).
+    if (lines.stream().allMatch(line -> line.startsWith("///"))) {
+      return preserveIndentation(lines, column0);
+    }
+
     if (tok.isSlashSlashComment()) {
       return indentLineComments(lines, column0);
     }

--- a/core/src/test/resources/com/google/googlejavaformat/java/testdata/B38241237.output
+++ b/core/src/test/resources/com/google/googlejavaformat/java/testdata/B38241237.output
@@ -3,6 +3,6 @@ class B38241237 {
   // bar
   // one long incredibly unbroken sentence moving from topic to topic so that no-one had a chance to
   // interrupt
-  /// baz
+  ///baz
   ////
 }


### PR DESCRIPTION
This is a crude solution to support markdown javadoc comments by not touching anything that looks like one.