### PR TITLE
Fix google-java-format reformatting code formatted by Android Studio for Platform when running with AOSP style

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Formatter.java
@@ -28,6 +28,7 @@ import com.google.errorprone.annotations.Immutable;
 import com.google.googlejavaformat.Doc;
 import com.google.googlejavaformat.DocBuilder;
 import com.google.googlejavaformat.FormattingError;
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
 import com.google.googlejavaformat.Newlines;
 import com.google.googlejavaformat.Op;
 import com.google.googlejavaformat.OpsBuilder;
@@ -156,7 +157,7 @@ public final class Formatter {
           createVisitor(
               "com.google.googlejavaformat.java.java21.Java21InputAstVisitor", builder, options);
     } else {
-      visitor = new JavaInputAstVisitor(builder, options.indentationMultiplier());
+      visitor = new JavaInputAstVisitor(builder, options.indentationMultiplier(), options.style());
     }
     visitor.scan(unit, null);
     builder.sync(javaInput.getText().length());
@@ -172,8 +173,8 @@ public final class Formatter {
     try {
       return Class.forName(className)
           .asSubclass(JavaInputAstVisitor.class)
-          .getConstructor(OpsBuilder.class, int.class)
-          .newInstance(builder, options.indentationMultiplier());
+          .getConstructor(OpsBuilder.class, int.class, Style.class)
+          .newInstance(builder, options.indentationMultiplier(), options.style());
     } catch (ReflectiveOperationException e) {
       throw new LinkageError(e.getMessage(), e);
     }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -792,7 +792,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     token("do");
     visitStatement(
         node.getStatement(),
-        CollapseEmptyOrNot.YES,
+        useAospStyle() ? CollapseEmptyOrNot.NO : CollapseEmptyOrNot.YES,
         AllowLeadingBlankLine.YES,
         AllowTrailingBlankLine.YES);
     if (node.getStatement().getKind() == BLOCK) {

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -525,7 +525,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       builder.close();
     }
     if (node.getInitializers() != null) {
-      if (node.getType() != null) {
+      if (!useAospStyle() && node.getType() != null) {
         builder.space();
       }
       visitArrayInitializer(node.getInitializers());

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -1671,7 +1671,11 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   private void methodBody(MethodTree node) {
     if (node.getBody().getStatements().isEmpty()) {
-      builder.blankLineWanted(BlankLineWanted.NO);
+      if (useAospStyle()) {
+        builder.forcedBreak();
+      } else {
+        builder.blankLineWanted(BlankLineWanted.NO);
+      }
     } else {
       builder.open(plusTwo);
       builder.forcedBreak();

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3263,7 +3263,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
     // Are there method invocations or field accesses after the prefix?
     boolean trailingDereferences = !prefixes.isEmpty() && getLast(prefixes) < items.size() - 1;
 
-    builder.open(plusFour);
+    builder.open(useAospStyle() && inBinaryExpression ? ZERO : plusFour);
     for (int times = 0; times < prefixes.size(); times++) {
       builder.open(ZERO);
     }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -590,7 +590,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       boolean allowFilledElementsOnOwnLine = shortItems || !inMemberValuePair;
 
       builder.open(initializerIndent);
-      tokenBreakTrailingComment("{", initializerUnindent);
+      tokenBreakTrailingComment("{", initializerIndent);
       boolean hasTrailingComma = hasTrailingToken(builder.getInput(), expressions, ",");
       builder.breakOp(hasTrailingComma ? FillMode.FORCED : FillMode.UNIFIED, "", ZERO);
       if (allowFilledElementsOnOwnLine) {

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3930,7 +3930,11 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       if (braces.isYes()) {
         builder.space();
         tokenBreakTrailingComment("{", plusTwo);
-        builder.blankLineWanted(BlankLineWanted.NO);
+        if (useAospStyle()) {
+          builder.forcedBreak();
+        } else {
+          builder.blankLineWanted(BlankLineWanted.NO);
+        }
         builder.open(ZERO);
         if (builder.peekToken().equals(Optional.of(";"))) {
           builder.open(plusTwo);

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -80,6 +80,7 @@ import com.google.googlejavaformat.OpsBuilder.BlankLineWanted;
 import com.google.googlejavaformat.Output.BreakTag;
 import com.google.googlejavaformat.java.DimensionHelpers.SortedDims;
 import com.google.googlejavaformat.java.DimensionHelpers.TypeWithDims;
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
 import com.sun.source.tree.AnnotatedTypeTree;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayAccessTree;
@@ -308,6 +309,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   protected static final Indent.Const ZERO = Indent.Const.ZERO;
   protected final int indentMultiplier;
+  protected final Style style;
   protected final Indent.Const minusTwo;
   protected final Indent.Const minusFour;
   protected final Indent.Const plusTwo;
@@ -341,9 +343,10 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
    *
    * @param builder the {@link OpsBuilder}
    */
-  public JavaInputAstVisitor(OpsBuilder builder, int indentMultiplier) {
+  public JavaInputAstVisitor(OpsBuilder builder, int indentMultiplier, Style style) {
     this.builder = builder;
     this.indentMultiplier = indentMultiplier;
+    this.style = style;
     minusTwo = Indent.Const.make(-2, indentMultiplier);
     minusFour = Indent.Const.make(-4, indentMultiplier);
     plusTwo = Indent.Const.make(+2, indentMultiplier);
@@ -355,6 +358,10 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   private boolean inExpression() {
     return inExpression.peekLast();
+  }
+
+  private boolean useAospStyle() {
+    return style.equals(Style.AOSP);
   }
 
   @Override

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -4056,15 +4056,16 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   /**
    * Should a field with a set of modifiers be declared with horizontal annotations? This is
-   * currently true if all annotations are parameterless annotations.
+   * currently true if all annotations are parameterless annotations and we are not using 
+   * AOSP style.
    */
-  private static Direction fieldAnnotationDirection(ModifiersTree modifiers) {
+  private Direction fieldAnnotationDirection(ModifiersTree modifiers) {
     for (AnnotationTree annotation : modifiers.getAnnotations()) {
       if (!annotation.getArguments().isEmpty()) {
         return Direction.VERTICAL;
       }
     }
-    return Direction.HORIZONTAL;
+    return useAospStyle() ? Direction.VERTICAL : Direction.HORIZONTAL;
   }
 
   /**

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -307,6 +307,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   // Used to ensure correct indentation of subexpressions in aosp style
   private boolean inBinaryExpression = false;
+  private int dotExpressionLevel = 0;
 
   protected final OpsBuilder builder;
 
@@ -741,7 +742,11 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       visitAnnotations(annotations, BreakOrNot.NO, BreakOrNot.YES);
     }
     scan(node.getIdentifier(), null);
-    addArguments(node.getArguments(), plusFour);
+    if (useAospStyle()) {
+      addArguments(node.getArguments(), this.dotExpressionLevel > 0 ? ZERO : plusFour);
+    } else {
+      addArguments(node.getArguments(), plusFour);
+    }
     builder.close();
     if (node.getClassBody() != null) {
       addBodyDeclarations(
@@ -3094,6 +3099,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         token(".");
       } else {
         builder.open(plusFour);
+        this.dotExpressionLevel++;
         scan(getArrayBase(node), null);
         builder.breakOp();
         needDot = true;
@@ -3101,6 +3107,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       formatArrayIndices(getArrayIndices(node));
       if (stack.isEmpty()) {
         builder.close();
+        this.dotExpressionLevel--;
         return;
       }
     }
@@ -3171,6 +3178,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
     if (node != null) {
       builder.close();
+      this.dotExpressionLevel--;
     }
   }
 

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -536,6 +536,8 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
 
   public boolean visitArrayInitializer(List<? extends ExpressionTree> expressions) {
     int cols;
+    final Indent.Const initializerIndent = useAospStyle() ? plusFour : plusTwo;
+    final Indent.Const initializerUnindent = useAospStyle() ? minusFour : minusTwo;
     if (expressions.isEmpty()) {
       tokenBreakTrailingComment("{", plusTwo);
       if (builder.peekToken().equals(Optional.of(","))) {
@@ -543,7 +545,7 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       }
       token("}", plusTwo);
     } else if ((cols = argumentsAreTabular(expressions)) != -1) {
-      builder.open(plusTwo);
+      builder.open(initializerIndent);
       token("{");
       builder.forcedBreak();
       boolean afterFirstToken = false;
@@ -565,9 +567,9 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
         builder.close();
         afterFirstToken = true;
       }
-      builder.breakOp(minusTwo);
+      builder.breakOp(initializerUnindent);
       builder.close();
-      token("}", plusTwo);
+      token("}", initializerIndent);
     } else {
       // Special-case the formatting of array initializers inside annotations
       // to more eagerly use a one-per-line layout.
@@ -587,8 +589,8 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       boolean shortItems = hasOnlyShortItems(expressions);
       boolean allowFilledElementsOnOwnLine = shortItems || !inMemberValuePair;
 
-      builder.open(plusTwo);
-      tokenBreakTrailingComment("{", plusTwo);
+      builder.open(initializerIndent);
+      tokenBreakTrailingComment("{", initializerUnindent);
       boolean hasTrailingComma = hasTrailingToken(builder.getInput(), expressions, ",");
       builder.breakOp(hasTrailingComma ? FillMode.FORCED : FillMode.UNIFIED, "", ZERO);
       if (allowFilledElementsOnOwnLine) {
@@ -608,9 +610,9 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       if (allowFilledElementsOnOwnLine) {
         builder.close();
       }
-      builder.breakOp(minusTwo);
+      builder.breakOp(initializerUnindent);
       builder.close();
-      token("}", plusTwo);
+      token("}", initializerIndent);
     }
     return false;
   }

--- a/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/JavaInputAstVisitor.java
@@ -3989,7 +3989,11 @@ public class JavaInputAstVisitor extends TreePathScanner<Void, Void> {
       return;
     }
     builder.breakToFill(" ");
-    builder.open(types.size() > 1 ? plusFour : ZERO);
+    if (useAospStyle()) {
+      builder.open(ZERO);
+    } else {
+      builder.open(types.size() > 1 ? plusFour : ZERO);
+    }
     token(token);
     builder.space();
     boolean afterFirstToken = false;

--- a/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/java21/Java21InputAstVisitor.java
@@ -15,6 +15,7 @@
 package com.google.googlejavaformat.java.java21;
 
 import com.google.googlejavaformat.OpsBuilder;
+import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
 import com.google.googlejavaformat.java.JavaInputAstVisitor;
 import com.sun.source.tree.CaseTree;
 import com.sun.source.tree.ConstantCaseLabelTree;
@@ -33,8 +34,8 @@ import javax.lang.model.element.Name;
  */
 public class Java21InputAstVisitor extends JavaInputAstVisitor {
 
-  public Java21InputAstVisitor(OpsBuilder builder, int indentMultiplier) {
-    super(builder, indentMultiplier);
+  public Java21InputAstVisitor(OpsBuilder builder, int indentMultiplier, Style style) {
+    super(builder, indentMultiplier, style);
   }
 
   @Override


### PR DESCRIPTION
Google-java-format when using AOSP style will reformat code that was already formatted by Google's Android Studio for Platform IDE (and vice versa). Both styles are compliant with the guidelines specified in [AOSP Java code style for contributors](https://source.android.com/docs/setup/contribute/code-style). This prevents formatters from clobbering each other by updating google-java-format to be compliant with Android Studio for Platform's format when running with `--aosp`. No changes are made to the standard format. 

Tested by formatting with Android Studio for Platform then google-java-format over multiple projects in AOSP and diffing to confirm no changes. All unit tests pass.