### PR TITLE
[core] add IDE agnostic configuration thus run `spotlessApply` on dev environment

### DIFF
--- a/.spotless/licence.header
+++ b/.spotless/licence.header
@@ -1,0 +1,14 @@
+/*
+ * Copyright $YEAR Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+

--- a/eclipse_plugin/pom.xml
+++ b/eclipse_plugin/pom.xml
@@ -19,11 +19,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.googlejavaformat</groupId>
   <artifactId>google-java-format-eclipse-plugin</artifactId>
   <packaging>eclipse-plugin</packaging>
   <version>1.13.0</version>
-
+  <parent>
+    <groupId>com.google.googlejavaformat</groupId>
+    <artifactId>google-java-format-parent</artifactId>
+    <version>HEAD-SNAPSHOT</version>
+  </parent>
   <name>Google Java Format Plugin for Eclipse 4.5+</name>
 
   <description>

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,56 @@
           <artifactId>maven-bundle-plugin</artifactId>
           <version>5.1.4</version>
         </plugin>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.44.5</version>
+          <configuration>
+            <formats>
+              <format>
+                <excludes>
+                  <exclude>**/testdata/**</exclude>
+                  <exclude>**gradlew**</exclude>
+                  <exclude>**mvnw**</exclude>
+                </excludes>
+                <includes>
+                  <include>.gitignore</include>
+                </includes>
+                <trimTrailingWhitespace/>
+              </format>
+            </formats>
+            <java>
+              <excludes>
+                <exclude>**/src/main/java/net/sourceforge/pmd/lang/java/types/package-info.java</exclude>
+                <exclude>**/testdata/**</exclude>
+                <exclude>**/unnecessaryimport/package1/U.java</exclude>
+              </excludes>
+              <googleJavaFormat/>
+              <removeUnusedImports/>
+              <licenseHeader>
+                <file>${maven.multiModuleProjectDirectory}/.spotless/licence.header</file>
+              </licenseHeader>
+            </java>
+          </configuration>
+          <executions>
+            <execution>
+              <id>spotless-apply</id>
+              <phase>process-sources</phase>
+              <goals>
+                <goal>apply</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>spotless-check</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
       </plugins>
+
     </pluginManagement>
 
     <plugins>
@@ -294,6 +343,10 @@
             --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
           </argLine>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION

### Automating Code Formatting with Spotless in Gradle

By binding the `spotlessApply` goal to local execution, we can automatically fix formatting issues during a single Gradle build when triggered for every push. This approach offers two key benefits:
1. **Time savings**: Eliminates back-and-forth CI/CD cycles for formatting fixes
2. **Resource efficiency**: Reduces cloud compute usage

This pattern is already well-established in major projects:
- **Maven** implements auto-fixing (though not in cloud environments):
  - [Maven Parent POM: spotless:apply binding](https://github.com/apache/maven-parent/blob/f4ab7c2eb04865071186c57a263243c72b6e8d52/pom.xml#L1415C11-L1415C30)
  - [Maven Parent POM: verify phase](https://github.com/apache/maven-parent/blob/f4ab7c2eb04865071186c57a263243c72b6e8d52/pom.xml#L1419)
- **Quarkus** follows similar practices
- **PMD** is implementing this approach: [PMD Issue #5651](https://github.com/pmd/pmd/issues/5651)

#### Current Limitations and Proof of Concept
While the concept is proven in Maven environments, Gradle/Spotless integration currently requires additional configuration:
- Builds don't auto-fix out of the box like Maven/Quarkus
- Related issues and PoC:
  - [Spotless Issue #2525](https://github.com/diffplug/spotless/issues/2525)
  - [Spotless PR #2528 (PoC)](https://github.com/diffplug/spotless/pull/2528)

![Example of formatting workflow](https://github.com/user-attachments/assets/1c87172a-51a5-4094-a20c-1980849b9157)
