### PR TITLE
feat: run string reflowing in IntelliJ plugin

### DIFF
--- a/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingService.java
+++ b/idea_plugin/src/main/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingService.java
@@ -23,6 +23,7 @@ import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
 import com.google.googlejavaformat.java.JavaFormatterOptions;
 import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+import com.google.googlejavaformat.java.StringWrapper;
 import com.intellij.formatting.service.AsyncDocumentFormattingService;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.ide.highlighter.JavaFileType;
@@ -101,6 +102,7 @@ public class GoogleJavaFormatFormattingService extends AsyncDocumentFormattingSe
     public void run() {
       try {
         String formattedText = formatter.formatSource(request.getDocumentText(), toRanges(request));
+        formattedText = StringWrapper.wrap(formattedText, formatter);
         request.onTextReady(formattedText);
       } catch (FormatterException e) {
         request.onError(

--- a/idea_plugin/src/test/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingServiceTest.java
+++ b/idea_plugin/src/test/java/com/google/googlejavaformat/intellij/GoogleJavaFormatFormattingServiceTest.java
@@ -23,6 +23,7 @@ import com.google.googlejavaformat.intellij.GoogleJavaFormatSettings.State;
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.JavaFormatterOptions;
 import com.google.googlejavaformat.java.JavaFormatterOptions.Style;
+import com.google.googlejavaformat.java.StringWrapper;
 import com.intellij.formatting.service.AsyncFormattingRequest;
 import com.intellij.formatting.service.FormattingService;
 import com.intellij.formatting.service.FormattingServiceUtil;
@@ -210,6 +211,25 @@ public class GoogleJavaFormatFormattingServiceTest {
                 file.findElementAt(offset), /* canChangeWhitespaceOnly= */ false));
 
     assertThat(file.getText()).containsMatch("/\\*\\* hello \\*/");
+    assertThat(delegatingFormatter.wasInvoked()).isTrue();
+  }
+
+  @Test
+  public void stringWrapper() throws Exception {
+    settings.setStyle(Style.GOOGLE);
+    PsiFile file =
+        createPsiFile(
+            "com/foo/FormatTest.java",
+            "class T {",
+            "  String s = \"foo \" + \"Some Very Long Text, foo bar foo bar foo bar foo bar foo bar"
+                + " foo bar foo bar foo bar foo bar\";",
+            "}");
+    String origText = file.getText();
+    CodeStyleManager manager = CodeStyleManager.getInstance(file.getProject());
+    WriteCommandAction.runWriteCommandAction(
+        file.getProject(), () -> manager.reformatText(file, 0, file.getTextLength()));
+
+    assertThat(file.getText()).isEqualTo(StringWrapper.wrap(origText, new Formatter()) + "\n");
     assertThat(delegatingFormatter.wasInvoked()).isTrue();
   }
 


### PR DESCRIPTION
Run string reflowing in the IntelliJ plugin, making the behavior of the IntelliJ plugin consistent with the default behavior when using the jar.

An alternative solution would be to provide an option like `--skip-reflowing-long-strings` in the IntelliJ plugin, but I believe their default behavior should remain consistent when no options are explicitly enabled.

Fixed #566