### PR TITLE
Handle escaped backslashes correctly when wrapping long strings.

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/StringWrapper.java
@@ -275,7 +275,7 @@ public final class StringWrapper {
           // continue below
         } else if (hasEscapedWhitespaceAt(text, idx) != -1) {
           // continue below
-        } else if (hasEscapedNewlineAt(text, idx) != -1) {
+        } else if (hasEscapedNewlineAt(text, idx) != -1 || hasEscapedBackslashAt(text, idx) != -1) {
           int length;
           while ((length = hasEscapedNewlineAt(text, idx)) != -1) {
             idx += length;
@@ -300,6 +300,13 @@ public final class StringWrapper {
       result.add(piece.toString());
     }
     return result.build();
+  }
+
+  static int hasEscapedBackslashAt(String input, int idx) {
+    if (input.startsWith("\\\\", idx)) {
+      return 2;
+    }
+    return -1;
   }
 
   static int hasEscapedWhitespaceAt(String input, int idx) {


### PR DESCRIPTION
Fixes #1253.
Escaped backslashes need to be handled while wrapping long strings, otherwise long strings containing "\\t" will cause the wrapping to fail.