### PR TITLE
Update LICENSE to Apache License version 2.0, 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ The following Apache 2.0 license applies to all code in this package except
 google-java-format-diff.py.
 
                                  Apache License
-                           Version 2.0, January 2004
+                           Version 2.0, January 2026
                         http://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION


### PR DESCRIPTION
Updated the Apache License version to January 2026.