### PR TITLE
Fix reflection errors during native execution

### DIFF
--- a/core/src/main/resources/META-INF/native-image/reachability-metadata.json
+++ b/core/src/main/resources/META-INF/native-image/reachability-metadata.json
@@ -1,0 +1,106 @@
+{
+  "reflection": [
+    {
+      "type": "com.google.googlejavaformat.java.JavacTokens$CommentSavingTokenizer"
+    },
+    {
+      "type": "com.sun.source.tree.CaseTree"
+    },
+    {
+      "type": "com.sun.source.tree.ImportTree",
+      "methods": [
+        {
+          "name": "isModule",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.parser.JavaTokenizer"
+    },
+    {
+      "type": "com.sun.tools.javac.parser.ParserFactory",
+      "methods": [
+        {
+          "name": "newParser",
+          "parameterTypes": [
+            "java.lang.CharSequence",
+            "boolean",
+            "boolean",
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.parser.UnicodeReader",
+      "methods": [
+        {
+          "name": "getRawCharacters",
+          "parameterTypes": [
+            "int",
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.tree.EndPosTable"
+    },
+    {
+      "type": "com.sun.tools.javac.tree.JCTree",
+      "methods": [
+        {
+          "name": "getEndPosition",
+          "parameterTypes": [
+            "com.sun.tools.javac.tree.EndPosTable"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.tree.JCTree$JCCompilationUnit",
+      "fields": [
+        {
+          "name": "endPositions"
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.tree.JCTree$JCImport",
+      "methods": [
+        {
+          "name": "getQualifiedIdentifier",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.tools.javac.util.Log$DeferredDiagnosticHandler",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.sun.tools.javac.util.Log"
+          ]
+        },
+        {
+          "name": "getDiagnostics",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/core/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/core/src/main/resources/META-INF/native-image/reflect-config.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name": "com.sun.tools.javac.parser.UnicodeReader",
-    "allDeclaredMethods": true
-  }
-]


### PR DESCRIPTION
Hi, after updating to the new version 1.34.0 I'm receiving this error running the native binary:

```
error: no such method: com.sun.tools.javac.tree.JCTree.getEndPosition(EndPosTable)int/invokeVirtual
java.lang.LinkageError: no such method: com.sun.tools.javac.tree.JCTree.getEndPosition(EndPosTable)int/invokeVirtual
        at com.google.googlejavaformat.java.Trees.getEndPosMethodHandle(Trees.java:278)
        at com.google.googlejavaformat.java.Trees.<clinit>(Trees.java:251)
        at com.google.googlejavaformat.java.Formatter.format(Formatter.java:104)
        at com.google.googlejavaformat.java.Formatter.getFormatReplacements(Formatter.java:214)
        at com.google.googlejavaformat.java.Formatter.formatSource(Formatter.java:188)
        at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:75)
        at com.google.googlejavaformat.java.FormatFileCallable.call(FormatFileCallable.java:29)
        at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
        at java.base@25.0.2/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
        at java.base@25.0.2/java.util.concurrent.FutureTask.run(FutureTask.java:328)
        at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base@25.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at java.base@25.0.2/java.lang.Thread.runWith(Thread.java:1487)
        at java.base@25.0.2/java.lang.Thread.run(Thread.java:1474)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
Caused by: java.lang.NoSuchMethodException: no such method: com.sun.tools.javac.tree.JCTree.getEndPosition(EndPosTable)int/invokeVirtual
        at java.base@25.0.2/java.lang.invoke.MemberName.makeAccessException(MemberName.java:910)
        at java.base@25.0.2/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:989)
        at java.base@25.0.2/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3591)
        at java.base@25.0.2/java.lang.invoke.MethodHandles$Lookup.findVirtual(MethodHandles.java:2610)
        at com.google.googlejavaformat.java.Trees.getEndPosMethodHandle(Trees.java:269)
        ... 15 more
Caused by: java.lang.NoSuchMethodError: com.sun.tools.javac.tree.JCTree.getEndPosition(com.sun.tools.javac.tree.EndPosTable)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.methodhandles.Util_java_lang_invoke_MethodHandleNatives.resolve(Target_java_lang_invoke_MethodHandleNatives.java:352)
        at java.base@25.0.2/java.lang.invoke.MethodHandleNatives.resolve(MethodHandleNatives.java:208)
        at java.base@25.0.2/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:120)
        at java.base@25.0.2/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:986)
        ... 18 more

```

It's caused by https://github.com/google/google-java-format/commit/4a15b1b9a4063a8ec2958ba3fc0924d1be046b93 that introduced new reflection invocations that the native build process isn't able to pick up.
Following [this guide](https://www.graalvm.org/latest/reference-manual/native-image/metadata/AutomaticMetadataCollection/) I generated an updated config file to fix the problem. The config file name changed in Graal 23, but it's only used during build time so it shouldn't matter that much.

With this fix everything works fine (at least for my case :grin:).