### PR TITLE
Add simple native formatting test

### DIFF
--- a/util/HelloWorld.java
+++ b/util/HelloWorld.java
@@ -1,0 +1,8 @@
+class HelloWorld {
+    public static void main(String[] args) {
+        System
+                .out
+                .println
+                        ("Hello, World!");
+    }
+}

--- a/util/test-native.sh
+++ b/util/test-native.sh
@@ -28,3 +28,5 @@ if [[ $status -ne 2 ]]; then
   echo "google-java-format_linux (native) without arguments should have printed usage help and exited with 2, but did not :("
   exit 1
 fi
+
+core/target/google-java-format util/HelloWorld.java


### PR DESCRIPTION
As discussed in https://github.com/google/google-java-format/pull/1327 a very simple formatting test is added to the native build.

It's a fairly basic smoke test, but I actually verified here https://github.com/EvaristeGalois11/google-java-format/pull/1 that it's enough to catch problems like the recent bug :grin: 