### PR TITLE
Add CLI flag to disable modifier reordering

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptions.java
@@ -39,6 +39,7 @@ import java.util.Optional;
  *     normally.
  * @param setExitIfChanged Return exit code 1 if there are any formatting changes.
  * @param assumeFilename Return the name to use for diagnostics when formatting standard input.
+ * @param reorderModifiers Reorder modifiers into the JLS-recommended order.
  */
 record CommandLineOptions(
     ImmutableList<String> files,
@@ -57,7 +58,8 @@ record CommandLineOptions(
     boolean setExitIfChanged,
     Optional<String> assumeFilename,
     boolean reflowLongStrings,
-    boolean formatJavadoc) {
+    boolean formatJavadoc,
+    boolean reorderModifiers) {
 
   /** Returns true if partial formatting was selected. */
   boolean isSelection() {
@@ -70,6 +72,7 @@ record CommandLineOptions(
         .removeUnusedImports(true)
         .reflowLongStrings(true)
         .formatJavadoc(true)
+        .reorderModifiers(true)
         .aosp(false)
         .version(false)
         .help(false)
@@ -128,6 +131,8 @@ record CommandLineOptions(
     Builder reflowLongStrings(boolean reflowLongStrings);
 
     Builder formatJavadoc(boolean formatJavadoc);
+
+    Builder reorderModifiers(boolean reorderModifiers);
 
     CommandLineOptions build();
   }

--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
@@ -79,6 +79,7 @@ final class CommandLineOptionsParser {
         case "--skip-removing-unused-imports" -> optionsBuilder.removeUnusedImports(false);
         case "--skip-reflowing-long-strings" -> optionsBuilder.reflowLongStrings(false);
         case "--skip-javadoc-formatting" -> optionsBuilder.formatJavadoc(false);
+        case "--skip-reordering-modifiers" -> optionsBuilder.reorderModifiers(false);
         case "-" -> optionsBuilder.stdin(true);
         case "-n", "--dry-run" -> optionsBuilder.dryRun(true);
         case "--set-exit-if-changed" -> optionsBuilder.setExitIfChanged(true);

--- a/core/src/main/java/com/google/googlejavaformat/java/Main.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/Main.java
@@ -120,6 +120,7 @@ public final class Main {
         JavaFormatterOptions.builder()
             .style(parameters.aosp() ? Style.AOSP : Style.GOOGLE)
             .formatJavadoc(parameters.formatJavadoc())
+            .reorderModifiers(parameters.reorderModifiers())
             .build();
 
     if (parameters.stdin()) {

--- a/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
@@ -46,6 +46,8 @@ Options:
     Do not reflow string literals that exceed the column limit.
   --skip-javadoc-formatting
     Do not reformat javadoc.
+  --skip-reordering-modifiers
+    Do not reorder modifiers into the JLS-recommended order.
   --dry-run, -n
     Prints the paths of the files whose contents would change if the formatter were run normally.
   --set-exit-if-changed

--- a/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
@@ -53,6 +53,7 @@ public class CommandLineOptionsParserTest {
     assertThat(options.setExitIfChanged()).isFalse();
     assertThat(options.reflowLongStrings()).isTrue();
     assertThat(options.formatJavadoc()).isTrue();
+    assertThat(options.reorderModifiers()).isTrue();
   }
 
   @Test
@@ -198,6 +199,14 @@ public class CommandLineOptionsParserTest {
     assertThat(
             CommandLineOptionsParser.parse(Arrays.asList("--skip-javadoc-formatting"))
                 .formatJavadoc())
+        .isFalse();
+  }
+
+  @Test
+  public void skipReorderingModifiers() {
+    assertThat(
+            CommandLineOptionsParser.parse(Arrays.asList("--skip-reordering-modifiers"))
+                .reorderModifiers())
         .isFalse();
   }
 }

--- a/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/MainTest.java
@@ -639,6 +639,25 @@ class T {
   }
 
   @Test
+  public void noReorderModifiers() throws Exception {
+    String input =
+        """
+        class Test {
+          static public void main(String... args) {}
+        }
+        """;
+    InputStream in = new ByteArrayInputStream(input.getBytes(UTF_8));
+    StringWriter out = new StringWriter();
+    Main main =
+        new Main(
+            new PrintWriter(out, true),
+            new PrintWriter(new BufferedWriter(new OutputStreamWriter(System.err, UTF_8)), true),
+            in);
+    assertThat(main.format("--skip-reordering-modifiers", "-")).isEqualTo(0);
+    assertThat(out.toString()).isEqualTo(input);
+  }
+
+  @Test
   public void syntaxError() throws Exception {
     Path path = testFolder.newFile("Test.java").toPath();
     String input =


### PR DESCRIPTION
The library API already supports `JavaFormatterOptions.reorderModifiers(false)`, but the CLI had no equivalent flag.

This change adds `--skip-reordering-modifiers` and wires it through the CLI into `JavaFormatterOptions`.

The default CLI behavior is unchanged.