### PR TITLE
Add --google-style to select Google Style

### DIFF
--- a/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/CommandLineOptionsParser.java
@@ -72,6 +72,7 @@ final class CommandLineOptionsParser {
         case "--offset", "-offset" -> optionsBuilder.addOffset(parseInteger(it, flag, value));
         case "--length", "-length" -> optionsBuilder.addLength(parseInteger(it, flag, value));
         case "--aosp", "-aosp", "-a" -> optionsBuilder.aosp(true);
+        case "--no-aosp", "-no-aosp" -> optionsBuilder.aosp(false);
         case "--version", "-version", "-v" -> optionsBuilder.version(true);
         case "--help", "-help", "-h" -> optionsBuilder.help(true);
         case "--fix-imports-only" -> optionsBuilder.fixImportsOnly(true);

--- a/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
+++ b/core/src/main/java/com/google/googlejavaformat/java/UsageException.java
@@ -36,6 +36,9 @@ Options:
     File name to use for diagnostics when formatting standard input (default is <stdin>).
   --aosp, -aosp, -a
     Use AOSP style instead of Google Style (4-space indentation).
+  --no-aosp, -no-aosp
+    Use Google Style (2-space indentation). If both --aosp and --no-aosp are given, the last
+    one wins.
   --fix-imports-only
     Fix import order and remove any unused imports, but do no other formatting.
   --skip-sorting-imports

--- a/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
+++ b/core/src/test/java/com/google/googlejavaformat/java/CommandLineOptionsParserTest.java
@@ -78,6 +78,15 @@ public class CommandLineOptionsParserTest {
   }
 
   @Test
+  public void noAosp() {
+    assertThat(CommandLineOptionsParser.parse(Arrays.asList("--no-aosp")).aosp()).isFalse();
+    assertThat(CommandLineOptionsParser.parse(Arrays.asList("--aosp", "--no-aosp")).aosp())
+        .isFalse();
+    assertThat(CommandLineOptionsParser.parse(Arrays.asList("--no-aosp", "--aosp")).aosp())
+        .isTrue();
+  }
+
+  @Test
   public void help() {
     assertThat(CommandLineOptionsParser.parse(Arrays.asList("-help")).help()).isTrue();
   }


### PR DESCRIPTION
--aosp was the only style switch, with no way to select Google style once it had been passed. Wrapper scripts such as Chromium's google-java-format launcher append --aosp unconditionally, leaving projects that format through them no way to opt back into Google Style.

Add a --google-style flag, and allow overriding a previously given style. When both --aosp and --google-style are given, the last one wins.
